### PR TITLE
Use random color for new items and workspaces

### DIFF
--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -38,7 +38,7 @@ function setDraft(item: Item) {
 
 watch(model, isOpen => {
   if (isOpen) {
-    setDraft(editingItem.value)
+    setDraft(isEditing.value ? editingItem.value : constructEmptyItem())
   } else {
     formRef.value?.resetValidation()
   }

--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -25,12 +25,14 @@ const editingItem = computed(
 
 // Draft State
 const draft = ref<Item>(constructEmptyItem())
+const original = ref<Item>(constructEmptyItem())
 const startDateDraft = ref('')
 const endDateDraft = ref('')
-const changesMade = computed(() => !areItemsEqual(draft.value, editingItem.value))
+const changesMade = computed(() => !areItemsEqual(draft.value, original.value))
 
 // Draft Management
 function setDraft(item: Item) {
+  original.value = item
   draft.value = { ...item }
   startDateDraft.value = dateToShortISOString(item.startDate)
   endDateDraft.value = dateToShortISOString(item.endDate)

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -34,7 +34,7 @@ function setDraft(workspace: Workspace) {
 
 watch(model, isOpen => {
   if (isOpen) {
-    setDraft(editingWorkspace.value)
+    setDraft(isEditing.value ? editingWorkspace.value : constructEmptyWorkspace())
   } else {
     formRef.value?.resetValidation()
   }

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -25,10 +25,12 @@ const editingWorkspace = computed(
 
 // Draft state
 const draft = ref<Workspace>(constructEmptyWorkspace())
-const changesMade = computed(() => !areWorkspacesEqual(draft.value, editingWorkspace.value))
+const original = ref<Workspace>(constructEmptyWorkspace())
+const changesMade = computed(() => !areWorkspacesEqual(draft.value, original.value))
 
 // Draft management
 function setDraft(workspace: Workspace) {
+  original.value = { ...workspace, items: [...workspace.items] }
   draft.value = { ...workspace, items: [...workspace.items] }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+function randomColor(): string {
+  return `#${Math.floor(Math.random() * 0xFFFFFF).toString(16).padStart(6, '0')}`
+}
+
 // === WORKSPACES ===
 export interface Workspace {
   name: string;
@@ -10,7 +14,7 @@ export function constructEmptyWorkspace(): Workspace {
   return {
     name: '',
     description: '',
-    color: '#000000',
+    color: randomColor(),
     items: []
   }
 }
@@ -57,7 +61,7 @@ export function constructEmptyItem(): Item {
     description: '',
     startDate: today,
     endDate: today,
-    color: '#000000',
+    color: randomColor(),
   }
 }
 


### PR DESCRIPTION
## Summary
- Added a `randomColor()` helper function in `src/types.ts`
- Updated `constructEmptyWorkspace()` and `constructEmptyItem()` to use a random color instead of hardcoded `#000000` when creating new entries

## Test plan
- [ ] Open the item editor in create mode — verify the color field shows a random color (not black)
- [ ] Open the workspace editor in create mode — verify the color field shows a random color (not black)
- [ ] Verify editing existing items/workspaces still shows their saved color

🤖 Generated with [Claude Code](https://claude.com/claude-code)