### PR TITLE
Add favorite workspace feature

### DIFF
--- a/src/components/workspaces/WorkspaceCard.vue
+++ b/src/components/workspaces/WorkspaceCard.vue
@@ -3,7 +3,6 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import ItemList from '../items/ItemList.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
-import { constructEmptyWorkspace } from '@/types'
 import { useInterfaceStore } from '@/stores/interface';
 
 const props = defineProps<{
@@ -17,6 +16,12 @@ const userInterface = useInterfaceStore()
 const workspace = computed(() => workspacesStore.getWorkspace(props.workspaceId))
 
 const hovered = ref(false)
+
+const isFavorite = computed(() => userInterface.favoriteWorkspaceId === props.workspaceId)
+
+function toggleFavorite() {
+  userInterface.setFavoriteWorkspace(isFavorite.value ? null : props.workspaceId)
+}
 </script>
 
 <template>
@@ -28,18 +33,25 @@ const hovered = ref(false)
     @mouseleave="hovered = false"
   >
     <template #append>
-      <div class="actions" :class="{ visible: hovered }">
+      <div class="actions" :class="{ visible: hovered || isFavorite }">
         <v-btn
           icon="mdi-pencil"
           density="compact"
-          variant="text" 
+          variant="text"
           @click="userInterface.openWorkspaceEditor(workspaceId)"
         />
-        <v-btn 
+        <v-btn
           icon="mdi-open-in-new"
           density="compact"
           variant="text"
           @click="router.push({ name: 'workspace', params: { workspaceId } })"
+        />
+        <v-btn
+          :icon="isFavorite ? 'mdi-star' : 'mdi-star-outline'"
+          :color="isFavorite ? 'yellow' : undefined"
+          density="compact"
+          variant="text"
+          @click="toggleFavorite"
         />
       </div>
     </template>

--- a/src/components/workspaces/WorkspaceCard.vue
+++ b/src/components/workspaces/WorkspaceCard.vue
@@ -33,22 +33,26 @@ function toggleFavorite() {
     @mouseleave="hovered = false"
   >
     <template #append>
-      <div class="actions" :class="{ visible: hovered || isFavorite }">
-        <v-btn
-          icon="mdi-pencil"
-          density="compact"
-          variant="text"
-          @click="userInterface.openWorkspaceEditor(workspaceId)"
-        />
-        <v-btn
-          icon="mdi-open-in-new"
-          density="compact"
-          variant="text"
-          @click="router.push({ name: 'workspace', params: { workspaceId } })"
-        />
+      <div class="d-flex align-center">
+        <div class="actions" :class="{ visible: hovered }">
+          <v-btn
+            icon="mdi-pencil"
+            density="compact"
+            variant="text"
+            @click="userInterface.openWorkspaceEditor(workspaceId)"
+          />
+          <v-btn
+            icon="mdi-open-in-new"
+            density="compact"
+            variant="text"
+            @click="router.push({ name: 'workspace', params: { workspaceId } })"
+          />
+        </div>
         <v-btn
           :icon="isFavorite ? 'mdi-star' : 'mdi-star-outline'"
           :color="isFavorite ? 'yellow' : undefined"
+          class="star-btn"
+          :class="{ visible: isFavorite || hovered }"
           density="compact"
           variant="text"
           @click="toggleFavorite"
@@ -71,6 +75,14 @@ function toggleFavorite() {
 }
 
 .actions.visible {
+  visibility: visible;
+}
+
+.star-btn {
+  visibility: hidden;
+}
+
+.star-btn.visible {
   visibility: visible;
 }
 </style>

--- a/src/components/workspaces/WorkspacesPanel.vue
+++ b/src/components/workspaces/WorkspacesPanel.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import WorkspaceCard from './WorkspaceCard.vue'
 import { useInterfaceStore } from '@/stores/interface'
 
-defineProps<{
+const props = defineProps<{
   workspaceIds: Array<string>
 }>()
 
 const model = defineModel<boolean>()
 
 const userInterface = useInterfaceStore()
+
+const sortedWorkspaceIds = computed(() => {
+  const favorite = userInterface.favoriteWorkspaceId
+  if (!favorite || !props.workspaceIds.includes(favorite)) return props.workspaceIds
+  return [favorite, ...props.workspaceIds.filter(id => id !== favorite)]
+})
 
 function addWorkspace() {
   userInterface.openWorkspaceCreator()
@@ -30,7 +37,7 @@ function addWorkspace() {
     <!-- BODY -->
     <div class="pa-3 d-flex flex-column ga-3">
       <WorkspaceCard
-        v-for="workspaceId in workspaceIds"
+        v-for="workspaceId in sortedWorkspaceIds"
         :key="workspaceId"
         :workspaceId="workspaceId"
       />

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -9,7 +9,7 @@ import { DEFAULT_INTERVAL, DEFAULT_LIST_WIDTH, DEFAULT_PIXELS_PER_DAY } from '@/
  * Stored as a single record in the `settings` object store under the key `"app"`.
  */
 export interface AppSettings {
-  lastViewedWorkspaceId: string | null
+  favoriteWorkspaceId: string | null
   pixelsPerDay: number
   gridInterval: RoadmapInterval
   roadmapListWidth: number
@@ -123,7 +123,7 @@ export async function getSettings(): Promise<AppSettings | undefined> {
 
 export function makeDefaultSettings(): AppSettings {
   return {
-    lastViewedWorkspaceId: null,
+    favoriteWorkspaceId: null,
     pixelsPerDay: DEFAULT_PIXELS_PER_DAY,
     gridInterval: DEFAULT_INTERVAL,
     roadmapListWidth: DEFAULT_LIST_WIDTH

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -7,19 +7,18 @@ import { DEFAULT_INTERVAL, DEFAULT_LIST_WIDTH, DEFAULT_PIXELS_PER_DAY } from "@/
 
 export const useInterfaceStore = defineStore('interface', () => {
 
-  let restoredWorkspaceId: string | undefined | null
+  const favoriteWorkspaceId = ref<string | null>(null)
   const defaultWorkspaceId = computed(() => {
     const workspacesStore = useWorkspacesStore()
 
     if (!workspacesStore.hasWorkspaces) return undefined
     if (
-      !restoredWorkspaceId ||
-      !workspacesStore.doesWorkspaceExist(restoredWorkspaceId)
+      favoriteWorkspaceId.value &&
+      workspacesStore.doesWorkspaceExist(favoriteWorkspaceId.value)
     ) {
-      return workspacesStore.workspaceIds[0]
-    } else {
-      return restoredWorkspaceId
+      return favoriteWorkspaceId.value
     }
+    return workspacesStore.workspaceIds[0]
   })
 
   const pixelsPerDay = ref<number>(DEFAULT_PIXELS_PER_DAY)
@@ -38,14 +37,15 @@ export const useInterfaceStore = defineStore('interface', () => {
   async function initializeInterface() {
     const settings = (await getSettings()) || makeDefaultSettings()
 
-    restoredWorkspaceId = settings.lastViewedWorkspaceId
+    favoriteWorkspaceId.value = settings.favoriteWorkspaceId
     pixelsPerDay.value = settings.pixelsPerDay
     gridInterval.value = settings.gridInterval
     roadmapListWidth.value = settings.roadmapListWidth
   }
 
-  async function persistLastViewedWorkspace(id: string) {
-    await putSettings({ lastViewedWorkspaceId: id })
+  async function setFavoriteWorkspace(id: string | null) {
+    favoriteWorkspaceId.value = id
+    await putSettings({ favoriteWorkspaceId: id })
   }
 
   async function updateRoadmapScale(scale: RoadmapScale) {
@@ -147,6 +147,7 @@ export const useInterfaceStore = defineStore('interface', () => {
   }
 
   return {
+    favoriteWorkspaceId,
     defaultWorkspaceId,
     workspacesOpen,
     openWorkspaces,
@@ -171,7 +172,7 @@ export const useInterfaceStore = defineStore('interface', () => {
     confirm,
     resolveSpeedbump,
     initializeInterface,
-    persistLastViewedWorkspace,
+    setFavoriteWorkspace,
     roadmapScale,
     roadmapListWidthPx,
     roadmapListWidth,

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -22,9 +22,6 @@ const workspaceParam = computed(() => route.params.workspaceId as string)
 
 const activeWorkspace = computed(() => workspaceParam.value || userInterface.defaultWorkspaceId)
 
-watch(activeWorkspace, id => {
-  if (id) userInterface.persistLastViewedWorkspace(id)
-})
 const workspaceName = computed(() => activeWorkspace.value ?
     workspacesStore.getWorkspaceName(activeWorkspace.value) :
     ''


### PR DESCRIPTION
## Summary
- Users can star a workspace in the workspace list to mark it as their default
- Star icon is outline-only and shown on hover for non-favorites; filled yellow and always visible for the current favorite
- Clicking the filled star removes the favorite (falls back to first workspace as default)
- `favoriteWorkspaceId` replaces `lastViewedWorkspaceId` in `AppSettings` and the interface store
- Removes the watch in `WorkspacesView` that persisted the last-viewed workspace ID

## Test plan
- [ ] Create multiple workspaces and verify the star icon appears on hover for each
- [ ] Click the star on a workspace — confirm it becomes filled yellow and always visible
- [ ] Reload the app — confirm the favorited workspace loads by default
- [ ] Click the filled star to remove the favorite — confirm it reverts to outline on hover
- [ ] Reload with no favorite — confirm the first workspace in the list loads by default
- [ ] Delete the favorited workspace — confirm the app falls back to the first workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)