### PR TITLE
Add deploy previews for pull requests

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,31 @@
+name: Cleanup Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove preview folder
+        run: |
+          PREVIEW_DIR="previews/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PREVIEW_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -r "$PREVIEW_DIR"
+            git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No preview folder found for PR #${{ github.event.pull_request.number }}, skipping."
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,8 @@ on:
     branches:
       - production
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 # Allow only one concurrent deployment
 concurrency:
@@ -17,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,18 +32,9 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          clean: true
+          clean-exclude: previews

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,65 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    # Only deploy previews for PRs from within this repository (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build:preview -- --base /Chronicle/previews/pr-${{ github.event.pull_request.number }}/
+
+      - name: Deploy Preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          target-folder: previews/pr-${{ github.event.pull_request.number }}
+          clean: true
+
+      - name: Find existing preview comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- deploy-preview -->'
+
+      - name: Post preview URL comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- deploy-preview -->
+            ## Deploy Preview
+
+            | Status | URL |
+            |--------|-----|
+            | ✅ Ready | https://alexjfdev.github.io/Chronicle/previews/pr-${{ github.event.pull_request.number }}/ |
+
+            > Built from commit ${{ github.event.pull_request.head.sha }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
+    "build:preview": "run-p type-check \"build-only -- --mode preview {@}\" --",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
     "lint": "run-s lint:*",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,7 +20,7 @@ const router = createRouter({
       name: 'items',
       component: () => import('../views/ItemsView.vue'),
     },
-    ...(import.meta.env.DEV ? [{
+    ...(import.meta.env.DEV || import.meta.env.MODE === 'preview' ? [{
       path: '/test',
       name: 'test',
       component: () => import('../views/TestView.vue'),


### PR DESCRIPTION
Closes #53

## Summary

- Adds a new `preview` Vite mode and `build:preview` npm script, distinct from local dev and production builds
- The `/test` route is accessible in preview builds (via `import.meta.env.MODE === 'preview'`) in addition to dev mode
- Switches the production deploy workflow to `JamesIves/github-pages-deploy-action` so the `gh-pages` branch can hold both the production build and preview subfolders side by side
- Adds `preview.yml` workflow: triggered on PR open/sync/reopen, builds with the PR-specific base path (`/Chronicle/previews/pr-{number}/`), deploys to that subfolder, and posts/updates a comment on the PR with the preview URL
- Adds `cleanup-preview.yml` workflow: removes the preview folder from `gh-pages` when a PR is closed

## Setup required

After merging, the GitHub Pages source in repository settings must be changed from **"GitHub Actions"** to **"Deploy from a branch"** (`gh-pages` branch, `/ (root)`). This is a one-time change needed to support per-PR subfolders.

## Test plan

- [ ] Merge to `production` and verify the production deploy workflow succeeds and the main site still works
- [ ] Open a test PR and verify `preview.yml` runs, deploys to `https://alexjfdev.github.io/Chronicle/previews/pr-{number}/`, and posts a comment
- [ ] Verify the `/test` route is accessible in the preview build
- [ ] Close the test PR and verify `cleanup-preview.yml` removes the preview folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)