### PR TITLE
Add empty state for workspaces with no items

### DIFF
--- a/src/components/items/ItemList.vue
+++ b/src/components/items/ItemList.vue
@@ -39,6 +39,12 @@ const viewLess = () => { expanded.value = false }
 <template>
   <div class="item-list bg-white text-black rounded-lg border">
 
+    <v-row v-if="model.length === 0" class="ma-0" align="center">
+      <v-col class="pa-2 text-center text-caption text-medium-emphasis">
+        No items
+      </v-col>
+    </v-row>
+
     <v-row
       v-for="(itemId, index) in visibleItems"
       :key="itemId"

--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -53,8 +53,11 @@ const { dateRange, svgWidth, intervalStarts } = useRoadmapTimeline(
   rootRef,
 )
 
+/** Number of rows to display — at least 2 when empty so the chart isn't invisible. */
+const rowCount = computed(() => Math.max(props.itemIds.length, 2))
+
 /** Full pixel height of the SVG canvas — one row per item, no padding. */
-const svgHeight = computed(() => props.itemIds.length * ROW_HEIGHT)
+const svgHeight = computed(() => rowCount.value * ROW_HEIGHT)
 
 /**
  * Derived bar geometry for every visible item. Each bar object carries:
@@ -90,12 +93,12 @@ const bars = computed(() =>
       <!-- Vertical grid lines at each interval boundary -->
       <SvgVerticalGridLines :intervalStarts="intervalStarts" :dateRange="dateRange" :scale="scale" :height="svgHeight" />
 
-      <!-- 
-        Horizontal row dividers matching the item list borders. 
+      <!--
+        Horizontal row dividers matching the item list borders.
         Increments of .5 ensure SVG renders lines in a single pixel and not between two pixels.
       -->
       <line
-        v-for="(_, index) in itemIds"
+        v-for="(_, index) in rowCount"
         :key="index"
         x1="0"
         :x2="svgWidth"
@@ -108,8 +111,8 @@ const bars = computed(() =>
 
       <!-- Row hover backgrounds -->
       <rect
-        v-for="(itemId, index) in itemIds"
-        :key="`bg-${itemId}`"
+        v-for="(_, index) in rowCount"
+        :key="`bg-${index}`"
         x="0"
         :y="index * ROW_HEIGHT"
         :width="svgWidth"

--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -53,8 +53,8 @@ const { dateRange, svgWidth, intervalStarts } = useRoadmapTimeline(
   rootRef,
 )
 
-/** Number of rows to display — at least 2 when empty so the chart isn't invisible. */
-const rowCount = computed(() => Math.max(props.itemIds.length, 2))
+/** Number of rows to display — at least 1 when empty so the chart isn't invisible. */
+const rowCount = computed(() => Math.max(props.itemIds.length, 1))
 
 /** Full pixel height of the SVG canvas — one row per item, no padding. */
 const svgHeight = computed(() => rowCount.value * ROW_HEIGHT)

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -121,11 +121,11 @@ function startDrag(event: MouseEvent, itemId: string) {
 
 .empty-row {
   height: v-bind(ROW_HEIGHT_PX);
-  border-top: 1px solid v-bind(LIST_BORDER_COLOR);
-
-  &:first-of-type {
-    border-top: none;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
 }
 
 .item-row {

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -79,6 +79,10 @@ function startDrag(event: MouseEvent, itemId: string) {
 <template>
   <div class="items-list-wrapper">
     <div class="resize-handle" @mousedown="startResizeDrag" />
+    <template v-if="itemIds.length === 0">
+      <div class="empty-row" />
+      <div class="empty-row" />
+    </template>
     <div
       v-for="(itemId, index) in itemIds"
       :key="itemId"
@@ -116,6 +120,15 @@ function startDrag(event: MouseEvent, itemId: string) {
   height: 100%;
   background-color: rgb(var(--v-theme-surface));
   border-right: 1px solid v-bind(SECTION_BORDER_COLOR);
+}
+
+.empty-row {
+  height: v-bind(ROW_HEIGHT_PX);
+  border-top: 1px solid v-bind(LIST_BORDER_COLOR);
+
+  &:first-of-type {
+    border-top: none;
+  }
 }
 
 .item-row {

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -79,7 +79,7 @@ function startDrag(event: MouseEvent, itemId: string) {
 <template>
   <div class="items-list-wrapper">
     <div class="resize-handle" @mousedown="startResizeDrag" />
-    <div v-if="itemIds.length === 0" class="empty-row">No Items</div>
+    <div v-if="itemIds.length === 0" class="empty-row">No items</div>
     <div
       v-for="(itemId, index) in itemIds"
       :key="itemId"

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -79,10 +79,7 @@ function startDrag(event: MouseEvent, itemId: string) {
 <template>
   <div class="items-list-wrapper">
     <div class="resize-handle" @mousedown="startResizeDrag" />
-    <template v-if="itemIds.length === 0">
-      <div class="empty-row" />
-      <div class="empty-row" />
-    </template>
+    <div v-if="itemIds.length === 0" class="empty-row">No Items</div>
     <div
       v-for="(itemId, index) in itemIds"
       :key="itemId"

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -52,10 +52,7 @@ async function newItem() {
       </div>
 
       <!-- Body: Items List & Roadmap Render -->
-      <div v-if="workspace.items.length === 0" class="empty-state text-medium-emphasis">
-        No items
-      </div>
-      <div v-else class="body">
+      <div class="body">
         <!-- Item List -->
         <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" />
 
@@ -120,11 +117,6 @@ async function newItem() {
       }
     }
 
-    .empty-state {
-      text-align: center;
-      padding: 24px 0;
-      font-size: 0.875rem;
-    }
   }
 }
 </style>

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -52,7 +52,10 @@ async function newItem() {
       </div>
 
       <!-- Body: Items List & Roadmap Render -->
-      <div class="body">
+      <div v-if="workspace.items.length === 0" class="empty-state text-medium-emphasis">
+        No items
+      </div>
+      <div v-else class="body">
         <!-- Item List -->
         <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" />
 
@@ -115,6 +118,12 @@ async function newItem() {
       .item-list {
         border-right: 1px solid v-bind(SECTION_BORDER_COLOR);
       }
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 24px 0;
+      font-size: 0.875rem;
     }
   }
 }

--- a/src/components/roadmap/roadmap-utils.ts
+++ b/src/components/roadmap/roadmap-utils.ts
@@ -70,7 +70,10 @@ export function snapIntervalEnd(date: Date, gridInterval: RoadmapInterval): Date
  * across all visible items. Boundaries are snapped to the interval via snapIntervalStart/End.
  */
 export function computeDateRange(items: Item[], scale: RoadmapScale): DateRange {
-  if (items.length === 0) return { start: new Date(0), end: new Date(0) }
+  if (items.length === 0) return { 
+    start: snapIntervalStart(new Date(), scale.gridInterval), 
+    end: snapIntervalEnd(new Date(), scale.gridInterval)
+  }
   let min = Infinity
   let max = -Infinity
   items.forEach((item) => {

--- a/src/components/workspaces/WorkspaceCard.vue
+++ b/src/components/workspaces/WorkspaceCard.vue
@@ -63,12 +63,21 @@ function toggleFavorite() {
 
     <v-card-text class="d-flex ga-8 flex-column">
       <MarkdownRenderer :content="workspace.description" />
-      <ItemList v-model="workspace.items"/>
+      <div v-if="workspace.items.length === 0" class="empty-state text-medium-emphasis">
+        No items
+      </div>
+      <ItemList v-else v-model="workspace.items"/>
     </v-card-text>
   </v-card>
 </template>
 
 <style scoped>
+.empty-state {
+  text-align: center;
+  padding: 12px 0;
+  font-size: 0.875rem;
+}
+
 .actions {
   display: flex;
   gap: 4px;

--- a/src/components/workspaces/WorkspaceCard.vue
+++ b/src/components/workspaces/WorkspaceCard.vue
@@ -63,21 +63,12 @@ function toggleFavorite() {
 
     <v-card-text class="d-flex ga-8 flex-column">
       <MarkdownRenderer :content="workspace.description" />
-      <div v-if="workspace.items.length === 0" class="empty-state text-medium-emphasis">
-        No items
-      </div>
-      <ItemList v-else v-model="workspace.items"/>
+      <ItemList v-model="workspace.items"/>
     </v-card-text>
   </v-card>
 </template>
 
 <style scoped>
-.empty-state {
-  text-align: center;
-  padding: 12px 0;
-  font-size: 0.875rem;
-}
-
 .actions {
   display: flex;
   gap: 4px;


### PR DESCRIPTION
## Summary
- `WorkspaceCard` now shows a "No items" placeholder instead of an empty `ItemList` when a workspace has no items
- `RoadmapPane` now shows a "No items" placeholder instead of empty item list + chart columns when a workspace has no items

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)