### PR TITLE
Add vertical today date line to roadmap

### DIFF
--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -30,7 +30,7 @@
 
 import { computed, toRef, useTemplateRef } from 'vue'
 import { storeToRefs } from 'pinia'
-import { CHART_BORDER_COLOR_PRIMARY, ROW_HEIGHT } from './constants'
+import { CHART_BORDER_COLOR_PRIMARY, ROW_HEIGHT, TODAY_LINE_COLOR } from './constants'
 import { xForDate } from './roadmap-utils'
 import SvgVerticalGridLines from './SvgVerticalGridLines.vue'
 import { useItemsStore } from '@/stores/items'
@@ -81,6 +81,9 @@ const bars = computed(() =>
     .filter(b => b !== null)
 )
 
+const todayX = computed(() => xForDate(new Date(), dateRange.value, scale.value))
+const showTodayLine = computed(() => todayX.value >= 0 && todayX.value <= svgWidth.value)
+
 </script>
 
 <template>
@@ -129,6 +132,17 @@ const bars = computed(() =>
         :y="bar.y"
         :width="bar.width"
         :color="bar.color"
+      />
+
+      <!-- Today vertical line -->
+      <line
+        v-if="showTodayLine"
+        :x1="todayX"
+        :x2="todayX"
+        y1="0"
+        :y2="svgHeight"
+        :stroke="TODAY_LINE_COLOR"
+        stroke-width="1"
       />
     </svg>
   </div>

--- a/src/components/roadmap/RoadmapHeader.vue
+++ b/src/components/roadmap/RoadmapHeader.vue
@@ -19,7 +19,7 @@ const { dateRange, svgWidth, intervalStarts } = useRoadmapTimeline(
   rootRef,
 )
 
-const svgHeight = ROW_HEIGHT * 3
+const svgHeight = ROW_HEIGHT * 2
 
 const todayX = computed(() => xForDate(new Date(), dateRange.value, scale.value))
 const showTodayLine = computed(() => todayX.value >= 0 && todayX.value <= svgWidth.value)
@@ -37,7 +37,7 @@ const showTodayLine = computed(() => todayX.value >= 0 && todayX.value <= svgWid
         v-for="week in intervalStarts"
         :key="week.getTime()"
         :x="xForDate(week, dateRange, scale) + 4"
-        y="40"
+        y="20"
       >
         {{ scale.headerLabel(week) }}
       </text>

--- a/src/components/roadmap/RoadmapHeader.vue
+++ b/src/components/roadmap/RoadmapHeader.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { toRef, useTemplateRef } from 'vue'
+import { computed, toRef, useTemplateRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { xForDate } from './roadmap-utils'
-import { ROW_HEIGHT } from './constants'
+import { ROW_HEIGHT, TODAY_LINE_COLOR } from './constants'
 import SvgVerticalGridLines from './SvgVerticalGridLines.vue'
 import { useRoadmapTimeline } from './useRoadmapTimeline'
 import { useInterfaceStore } from '@/stores/interface'
@@ -19,7 +19,10 @@ const { dateRange, svgWidth, intervalStarts } = useRoadmapTimeline(
   rootRef,
 )
 
-const svgHeight = ROW_HEIGHT * 2
+const svgHeight = ROW_HEIGHT * 3
+
+const todayX = computed(() => xForDate(new Date(), dateRange.value, scale.value))
+const showTodayLine = computed(() => todayX.value >= 0 && todayX.value <= svgWidth.value)
 
 </script>
 
@@ -37,6 +40,14 @@ const svgHeight = ROW_HEIGHT * 2
         y="40"
       >
         {{ scale.headerLabel(week) }}
+      </text>
+      <text
+        v-if="showTodayLine"
+        :x="todayX + 4"
+        :y="svgHeight - 5"
+        :fill="TODAY_LINE_COLOR"
+      >
+        Today
       </text>
     </svg>
   </div>

--- a/src/components/roadmap/constants.ts
+++ b/src/components/roadmap/constants.ts
@@ -19,3 +19,4 @@ export const CHART_BAR_PADDING = 6 // Vertical space on top and bottom of roadma
 export const CHART_BORDER_COLOR_PRIMARY = BORDER_COLOR_LIGHT
 export const DEFAULT_PIXELS_PER_DAY = 30
 export const DEFAULT_INTERVAL = 'week'
+export const TODAY_LINE_COLOR = '#f44336'


### PR DESCRIPTION
## Summary
- Adds a red vertical line in the chart SVG at today's x-position (computed via `xForDate`)
- Adds a "Today" label in the roadmap header, below the interval dates
- Adds a `TODAY_LINE_COLOR` constant (`#f44336`) to control the color for both
- The line and label are only rendered when today falls within the visible SVG bounds

Closes #59

## Test plan
- [ ] Open a roadmap with items that span today's date — verify a red vertical line appears at today's position in the chart
- [ ] Verify the "Today" label appears in the header below the interval date labels, in red
- [ ] Verify the line/label are absent when today is outside the date range of visible items

🤖 Generated with [Claude Code](https://claude.com/claude-code)