### PR TITLE
Add sort options to WorkspacesView

### DIFF
--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -18,7 +18,7 @@ const itemsStore = useItemsStore()
 const workspacesStore = useWorkspacesStore()
 const interfaceStore = useInterfaceStore()
 
-const isDraggable = computed(() => interfaceStore.sortOption === 'custom')
+const isDraggable = computed(() => interfaceStore.sortingIsCustom)
 
 const draggingItemId = ref<string | null>(null)
 const ghostX = ref(0)

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -9,6 +9,7 @@ import { startDragGesture } from './useDragGesture'
 const props = defineProps<{
   workspaceId: string
   listWidth: number
+  itemIds: string[]
 }>()
 
 const listWidthPx = computed(() => `${props.listWidth}px`)
@@ -17,7 +18,7 @@ const itemsStore = useItemsStore()
 const workspacesStore = useWorkspacesStore()
 const interfaceStore = useInterfaceStore()
 
-const itemIds = computed(() => workspacesStore.getWorkspace(props.workspaceId).items)
+const isDraggable = computed(() => interfaceStore.sortOption === 'custom')
 
 const draggingItemId = ref<string | null>(null)
 const ghostX = ref(0)
@@ -41,6 +42,7 @@ const ghostStyle = computed(() => ({
 }))
 
 function startDrag(event: MouseEvent, itemId: string) {
+  if (!isDraggable.value) return
   draggingItemId.value = itemId
   ghostX.value = event.clientX
   ghostY.value = event.clientY
@@ -87,7 +89,7 @@ function startDrag(event: MouseEvent, itemId: string) {
       :class="{ 'drag-target': itemId === draggingItemId }"
     >
       <template v-if="itemId !== draggingItemId">
-        <div class="drag-bar" @mousedown="startDrag($event, itemId)">
+        <div v-if="isDraggable" class="drag-bar" @mousedown="startDrag($event, itemId)">
           <v-icon>mdi-drag-horizontal</v-icon>
         </div>
         <div class="item-name" @click="interfaceStore.openItemViewer(itemId)">{{ itemsStore.getName(itemId) }}</div>

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -89,7 +89,13 @@ function startDrag(event: MouseEvent, itemId: string) {
       :class="{ 'drag-target': itemId === draggingItemId }"
     >
       <template v-if="itemId !== draggingItemId">
-        <div v-if="isDraggable" class="drag-bar" @mousedown="startDrag($event, itemId)">
+        <div
+          :class="{
+            'drag-bar' : true,
+            'invisible' : interfaceStore.sortOption !== 'custom'
+          }"
+          @mousedown="startDrag($event, itemId)"
+        >
           <v-icon>mdi-drag-horizontal</v-icon>
         </div>
         <div class="item-name" @click="interfaceStore.openItemViewer(itemId)">{{ itemsStore.getName(itemId) }}</div>
@@ -193,6 +199,10 @@ function startDrag(event: MouseEvent, itemId: string) {
     height: 100%;
     cursor: move;
     border-radius: 2px;
+
+    &.invisible {
+      visibility: hidden !important;
+    }
   }
 
   .settings-button {

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -36,9 +36,9 @@ const sortedItemIds = computed(() => {
     if (sortOption.value === 'name') {
       comparison = itemsStore.getName(a).localeCompare(itemsStore.getName(b))
     } else if (sortOption.value === 'startDate') {
-      comparison = itemsStore.getItem(a).startDate.getTime() - itemsStore.getItem(b).startDate.getTime()
+      comparison = itemsStore.getStartDate(a).getTime() - itemsStore.getStartDate(b).getTime()
     } else if (sortOption.value === 'endDate') {
-      comparison = itemsStore.getItem(a).endDate.getTime() - itemsStore.getItem(b).endDate.getTime()
+      comparison = itemsStore.getEndDate(a).getTime() - itemsStore.getEndDate(b).getTime()
     }
     return sortDirection.value === 'asc' ? comparison : -comparison
   })

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -7,6 +7,7 @@ import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useWorkspacesStore } from '@/stores/workspaces'
 import { useInterfaceStore } from '@/stores/interface'
+import { useItemsStore } from '@/stores/items'
 import AddItemMenu from '@/components/items/AddItemMenu.vue'
 
 const props = defineProps<{
@@ -15,13 +16,33 @@ const props = defineProps<{
 
 const workspacesStore = useWorkspacesStore()
 const userInterface = useInterfaceStore()
+const itemsStore = useItemsStore()
 
 const workspace = computed(() => workspacesStore.getWorkspace(props.workspaceId))
 
 const {
   roadmapListWidth: listWidth,
-  roadmapListWidthPx: listWidthPx
+  roadmapListWidthPx: listWidthPx,
+  sortOption,
+  sortDirection,
 } = storeToRefs(userInterface)
+
+const sortedItemIds = computed(() => {
+  const ids = [...workspace.value.items]
+  if (sortOption.value === 'custom') return ids
+
+  return ids.sort((a, b) => {
+    let comparison = 0
+    if (sortOption.value === 'name') {
+      comparison = itemsStore.getName(a).localeCompare(itemsStore.getName(b))
+    } else if (sortOption.value === 'startDate') {
+      comparison = itemsStore.getStartDate(a).getTime() - itemsStore.getStartDate(b).getTime()
+    } else if (sortOption.value === 'endDate') {
+      comparison = itemsStore.getEndDate(a).getTime() - itemsStore.getEndDate(b).getTime()
+    }
+    return sortDirection.value === 'asc' ? comparison : -comparison
+  })
+})
 
 function addItem(itemId: string) {
   workspacesStore.updateWorkspace(props.workspaceId, { items: [...workspace.value.items, itemId] })
@@ -48,16 +69,16 @@ async function newItem() {
             </template>
           </AddItemMenu>
         </div>
-        <RoadmapHeader :itemIds="workspace.items" />
+        <RoadmapHeader :itemIds="sortedItemIds" />
       </div>
 
       <!-- Body: Items List & Roadmap Render -->
       <div class="body">
         <!-- Item List -->
-        <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" />
+        <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" :item-ids="sortedItemIds" />
 
         <!-- Roadmap Chart -->
-        <RoadmapChart class="chart" :itemIds="workspace.items" />
+        <RoadmapChart class="chart" :itemIds="sortedItemIds" />
       </div>
     </div>
   </div>

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -36,9 +36,9 @@ const sortedItemIds = computed(() => {
     if (sortOption.value === 'name') {
       comparison = itemsStore.getName(a).localeCompare(itemsStore.getName(b))
     } else if (sortOption.value === 'startDate') {
-      comparison = itemsStore.getStartDate(a).getTime() - itemsStore.getStartDate(b).getTime()
+      comparison = itemsStore.getItem(a).startDate.getTime() - itemsStore.getItem(b).startDate.getTime()
     } else if (sortOption.value === 'endDate') {
-      comparison = itemsStore.getEndDate(a).getTime() - itemsStore.getEndDate(b).getTime()
+      comparison = itemsStore.getItem(a).endDate.getTime() - itemsStore.getItem(b).endDate.getTime()
     }
     return sortDirection.value === 'asc' ? comparison : -comparison
   })

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -5,6 +5,9 @@ import { useWorkspacesStore } from "./workspaces"
 import type { RoadmapInterval, RoadmapScale } from "@/components/roadmap/roadmap-utils"
 import { DEFAULT_INTERVAL, DEFAULT_LIST_WIDTH, DEFAULT_PIXELS_PER_DAY } from "@/components/roadmap/constants"
 
+export type SortOption = 'custom' | 'startDate' | 'endDate' | 'name'
+export type SortDirection = 'asc' | 'desc'
+
 export const useInterfaceStore = defineStore('interface', () => {
 
   const favoriteWorkspaceId = ref<string | null>(null)
@@ -33,6 +36,11 @@ export const useInterfaceStore = defineStore('interface', () => {
   })
   const roadmapListWidth = ref<number>(DEFAULT_LIST_WIDTH)
   const roadmapListWidthPx = computed(() => `${roadmapListWidth.value}px`)
+
+  const sortOption = ref<SortOption>('custom')
+  const sortDirection = ref<SortDirection>('asc')
+  function setSortOption(option: SortOption) { sortOption.value = option }
+  function setSortDirection(direction: SortDirection) { sortDirection.value = direction }
 
   async function initializeInterface() {
     const settings = (await getSettings()) || makeDefaultSettings()
@@ -181,5 +189,9 @@ export const useInterfaceStore = defineStore('interface', () => {
     settingsOpen,
     openSettings,
     closeSettings,
+    sortOption,
+    sortDirection,
+    setSortOption,
+    setSortDirection,
   }
 })

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -36,11 +36,13 @@ export const useInterfaceStore = defineStore('interface', () => {
   })
   const roadmapListWidth = ref<number>(DEFAULT_LIST_WIDTH)
   const roadmapListWidthPx = computed(() => `${roadmapListWidth.value}px`)
-
+  // Sorting
   const sortOption = ref<SortOption>('custom')
   const sortDirection = ref<SortDirection>('asc')
   function setSortOption(option: SortOption) { sortOption.value = option }
   function setSortDirection(direction: SortDirection) { sortDirection.value = direction }
+  const sortingIsCustom = computed(() => sortOption.value === 'custom')
+  const sortDirectionIsAscending = computed(() => sortDirection.value === 'asc')
 
   async function initializeInterface() {
     const settings = (await getSettings()) || makeDefaultSettings()
@@ -193,5 +195,7 @@ export const useInterfaceStore = defineStore('interface', () => {
     sortDirection,
     setSortOption,
     setSortDirection,
+    sortingIsCustom,
+    sortDirectionIsAscending
   }
 })

--- a/src/stores/items.ts
+++ b/src/stores/items.ts
@@ -109,6 +109,8 @@ export const useItemsStore = defineStore('items', () => {
     getItems,
     getName,
     getColor,
+    getStartDate,
+    getEndDate,
     updateItem,
     doesItemExist,
     validateItemExists,

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -3,12 +3,19 @@ import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import RoadmapPane from '@/components/roadmap/RoadmapPane.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
-import { useInterfaceStore } from '@/stores/interface'
+import { useInterfaceStore, type SortOption } from '@/stores/interface'
 
 const route = useRoute()
 const router = useRouter()
 const workspacesStore = useWorkspacesStore()
 const userInterface = useInterfaceStore()
+
+const sortOptions: { label: string; value: SortOption }[] = [
+  { label: 'Custom', value: 'custom' },
+  { label: 'By start date', value: 'startDate' },
+  { label: 'By end date', value: 'endDate' },
+  { label: 'By name', value: 'name' },
+]
 
 // Handle workspace being deleted while viewing
 watch(() => workspacesStore.workspaceIds, (ids) => {
@@ -44,6 +51,26 @@ const workspaceName = computed(() => activeWorkspace.value ?
         <div class="d-flex align-center ga-2">
           <v-icon>mdi-chart-gantt</v-icon>
           <span class="text-h6">{{ workspaceName }}</span>
+        </div>
+        <div class="d-flex align-center ga-2">
+          <v-select
+            :model-value="userInterface.sortOption"
+            :items="sortOptions"
+            item-title="label"
+            item-value="value"
+            density="compact"
+            hide-details
+            variant="outlined"
+            style="min-width: 160px;"
+            @update:model-value="userInterface.setSortOption($event)"
+          />
+          <v-btn
+            v-if="userInterface.sortOption !== 'custom'"
+            :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
+            flat
+            density="compact"
+            @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
+          />
         </div>
         <v-btn prepend-icon="mdi-cog" flat @click="userInterface.openSettings()">Settings</v-btn>
       </div>

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -63,15 +63,24 @@ const workspaceName = computed(() => activeWorkspace.value ?
               hide-details
               variant="outlined"
               style="min-width: 160px;"
+              label="Sort"
               @update:model-value="userInterface.setSortOption($event)"
             />
-            <v-btn
-              :style="userInterface.sortOption === 'custom' ? 'visibility: hidden' : ''"
-              :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
-              flat
-              density="compact"
-              @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
-            />
+            <v-tooltip 
+              :text="userInterface.sortDirection === 'asc' ? 'Ascending' : 'Descending'"
+              location="bottom"
+            >
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  :style="userInterface.sortOption === 'custom' ? 'visibility: hidden' : ''"
+                  :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
+                  flat
+                  density="compact"
+                  @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
+                />
+              </template>
+            </v-tooltip>
           </div>
           <v-btn prepend-icon="mdi-cog" flat @click="userInterface.openSettings()">Settings</v-btn>
         </div>

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -66,7 +66,7 @@ const workspaceName = computed(() => activeWorkspace.value ?
               @update:model-value="userInterface.setSortOption($event)"
             />
             <v-btn
-              v-if="userInterface.sortOption !== 'custom'"
+              :style="userInterface.sortOption === 'custom' ? 'visibility: hidden' : ''"
               :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
               flat
               density="compact"

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -52,27 +52,29 @@ const workspaceName = computed(() => activeWorkspace.value ?
           <v-icon>mdi-chart-gantt</v-icon>
           <span class="text-h6">{{ workspaceName }}</span>
         </div>
-        <div class="d-flex align-center ga-2">
-          <v-select
-            :model-value="userInterface.sortOption"
-            :items="sortOptions"
-            item-title="label"
-            item-value="value"
-            density="compact"
-            hide-details
-            variant="outlined"
-            style="min-width: 160px;"
-            @update:model-value="userInterface.setSortOption($event)"
-          />
-          <v-btn
-            v-if="userInterface.sortOption !== 'custom'"
-            :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
-            flat
-            density="compact"
-            @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
-          />
+        <div class="d-flex">
+          <div class="d-flex align-center ga-2">
+            <v-select
+              :model-value="userInterface.sortOption"
+              :items="sortOptions"
+              item-title="label"
+              item-value="value"
+              density="compact"
+              hide-details
+              variant="outlined"
+              style="min-width: 160px;"
+              @update:model-value="userInterface.setSortOption($event)"
+            />
+            <v-btn
+              v-if="userInterface.sortOption !== 'custom'"
+              :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
+              flat
+              density="compact"
+              @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
+            />
+          </div>
+          <v-btn prepend-icon="mdi-cog" flat @click="userInterface.openSettings()">Settings</v-btn>
         </div>
-        <v-btn prepend-icon="mdi-cog" flat @click="userInterface.openSettings()">Settings</v-btn>
       </div>
 
       <div class="roadmap-container">

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -67,17 +67,17 @@ const workspaceName = computed(() => activeWorkspace.value ?
               @update:model-value="userInterface.setSortOption($event)"
             />
             <v-tooltip 
-              :text="userInterface.sortDirection === 'asc' ? 'Ascending' : 'Descending'"
+              :text="userInterface.sortDirectionIsAscending ? 'Ascending' : 'Descending'"
               location="bottom"
             >
               <template #activator="{ props }">
                 <v-btn
                   v-bind="props"
-                  :style="userInterface.sortOption === 'custom' ? 'visibility: hidden' : ''"
-                  :icon="userInterface.sortDirection === 'asc' ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
+                  :style="userInterface.sortingIsCustom ? 'visibility: hidden' : ''"
+                  :icon="userInterface.sortDirectionIsAscending ? 'mdi-sort-ascending' : 'mdi-sort-descending'"
                   flat
                   density="compact"
-                  @click="userInterface.setSortDirection(userInterface.sortDirection === 'asc' ? 'desc' : 'asc')"
+                  @click="userInterface.setSortDirection(userInterface.sortDirectionIsAscending ? 'desc' : 'asc')"
                 />
               </template>
             </v-tooltip>


### PR DESCRIPTION
Closes #57

## Summary
- Adds a sort dropdown to the `WorkspacesView` header (left of the Settings button) with options: **Custom**, **By start date**, **By end date**, **By name**
- When a non-custom sort is selected, an ascending/descending toggle icon button appears next to the dropdown
- Sorting is computed reactively without modifying the stored item order
- Drag-and-drop reordering is hidden when a non-custom sort is active (since manual ordering only applies to the Custom sort)

## Test plan
- [ ] Select each sort option and verify items reorder correctly in the list and chart
- [ ] Toggle ascending/descending and verify the order reverses
- [ ] Verify the direction toggle is hidden when "Custom" is selected
- [ ] Verify drag-and-drop still works when "Custom" is selected
- [ ] Verify drag handles are hidden for non-custom sorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)