### PR TITLE
Add linting proposal (closes #60)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run lint:ci

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,6 +5,8 @@
     "browser": true
   },
   "categories": {
-    "correctness": "error"
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "warn"
   }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -51,3 +51,9 @@ I need to decide how I will implement persistence so that data can be saved betw
 
 Details in `settings-proposal.md`.
 Adopted proposal A. A navigation drawer will be better long term. Also, these settings will eventually grow in the "view" feature mentioned in the README.
+
+## Linting
+
+Details in `linting-proposal.md`.
+Adopting proposal A. The addition of additional packages to run linting automatically seems unnecessary. It is a good habit for developers to run linting on a regular basis. Automated linting running with a GitHub action will be enough.
+I will also adopt the recommendations about lint rule changes.

--- a/docs/linting-proposal.md
+++ b/docs/linting-proposal.md
@@ -1,0 +1,178 @@
+# Linting Proposal
+
+## Context
+
+The project already has a linting stack installed and configured — ESLint, oxlint, and Prettier were all included by the Vue project scaffolding tool. However, the current setup has two gaps:
+
+1. **The rules are minimal.** ESLint is configured with `pluginVue.configs['flat/essential']`, which is the smallest Vue rule set and only catches a narrow class of mistakes. oxlint is configured with only `"correctness": "error"`, covering basic correctness issues. Neither catches style inconsistencies, suspicious patterns, or many common Vue-specific mistakes.
+
+2. **Linting is not enforced.** Running `npm run lint` is a manual step with nothing requiring it before a commit or before a PR is merged. The IDE may surface some warnings, but these can be silently ignored.
+
+The npm scripts for linting already exist:
+
+```
+lint:oxlint  →  oxlint . --fix
+lint:eslint  →  eslint . --fix --cache
+format       →  prettier --write --experimental-cli src/
+lint         →  run-s lint:*
+```
+
+This proposal compares two approaches for making linting consistent and enforceable. Either option can be combined with a ruleset expansion; that concern is addressed at the end.
+
+---
+
+## Option A: CI Enforcement via GitHub Actions
+
+Add a GitHub Actions workflow that runs `npm run lint` on every pull request to `development`. Lint failures block merging.
+
+### What changes
+
+A new file `.github/workflows/lint.yml` is added alongside the existing deploy and preview workflows. No new dependencies are required.
+
+```yaml
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run lint
+```
+
+Because the existing `lint:eslint` script uses `--fix`, it would need to change to `eslint . --cache` (no `--fix`) in CI — otherwise the workflow silently applies fixes and passes even when the working tree had violations. The fix flags are still appropriate when running lint locally; this is handled by running `npm run lint` locally before pushing.
+
+Alternatively, the fix scripts stay as-is and the CI workflow runs lint without `--fix` by calling `oxlint .` and `eslint .` directly, or by adding separate `lint:ci` scripts.
+
+### Pros
+
+- **No local setup required.** Contributors do not need to configure anything. The check runs automatically on every PR.
+- **No new dependencies.** Uses infrastructure already in the project (GitHub Actions).
+- **Enforcement at the right boundary.** Code that fails lint cannot land in `development` regardless of how it was committed.
+- **Consistent environment.** Lint runs in the same clean Node environment on every PR, eliminating "it passes on my machine" issues.
+
+### Cons
+
+- **Slow feedback loop.** A developer only learns about lint failures after pushing and waiting for CI. Violations can accumulate across many commits before being surfaced.
+- **Does not help during development.** Local editing sessions still have no automatic lint feedback beyond what the IDE provides.
+
+---
+
+## Option B: Pre-commit Hooks via Husky and lint-staged
+
+Install `husky` to register a Git pre-commit hook and `lint-staged` to run linting on staged files before each commit. Commits with lint violations are blocked locally.
+
+### What changes
+
+Two packages are added as dev dependencies: `husky` and `lint-staged`.
+
+```
+npm install --save-dev husky lint-staged
+npx husky init
+```
+
+A pre-commit hook is created at `.husky/pre-commit`:
+
+```sh
+npx lint-staged
+```
+
+A `lint-staged` configuration is added to `package.json`:
+
+```json
+"lint-staged": {
+  "*.{vue,ts,mts,tsx}": [
+    "oxlint --fix",
+    "eslint --fix --cache"
+  ],
+  "*.{vue,ts,mts,tsx,json,css,md}": [
+    "prettier --write"
+  ]
+}
+```
+
+Because lint-staged runs on staged files only, it is fast even in a large project.
+
+### Pros
+
+- **Immediate feedback.** Violations are caught at commit time — before they are ever pushed — keeping them from accumulating.
+- **Automatic fixing.** The `--fix` flags in lint-staged mean many lint issues are corrected automatically as part of committing, rather than requiring a manual cleanup pass.
+- **No CI dependency.** The enforcement is purely local and works with or without a remote.
+
+### Cons
+
+- **Two new dependencies.** `husky` and `lint-staged` are added to `devDependencies`. Both are well-established and widely used, but they are still packages to maintain.
+- **Can be bypassed.** Any contributor can skip the hook with `git commit --no-verify`. This is sometimes necessary (e.g., committing a WIP) but also means enforcement is not absolute.
+- **Local environment variation.** The hook runs in each developer's local Node environment, which may differ from the environment used by other contributors or CI.
+- **Hook setup required.** New contributors must run `npm install` (which triggers `husky install` via a `prepare` script) for the hook to activate. If they skip `npm install`, the hook is absent.
+
+---
+
+## Ruleset Expansion
+
+Regardless of which enforcement option is chosen, the current rules are narrow enough that they may not catch real problems. Two targeted expansions are worth considering:
+
+### Vue rules: `essential` → `recommended`
+
+The current ESLint config uses `pluginVue.configs['flat/essential']`. Changing this to `pluginVue.configs['flat/recommended']` enables the full recommended Vue 3 rule set, which catches a wider range of component authoring mistakes (e.g., attribute ordering, `v-bind` shorthand consistency, slot usage).
+
+The change is one line in `eslint.config.ts`:
+
+```diff
+- ...pluginVue.configs['flat/essential'],
++ ...pluginVue.configs['flat/recommended'],
+```
+
+Running `npm run lint` after this change will surface any existing violations, which can be fixed or selectively disabled before the config is committed.
+
+### oxlint: add `suspicious` and `pedantic` categories
+
+The current `.oxlintrc.json` enables only `"correctness": "error"`. Adding `"suspicious"` catches patterns that are likely bugs even if syntactically valid. Adding `"pedantic"` enforces stricter code quality rules.
+
+```json
+{
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "warn"
+  }
+}
+```
+
+Using `"warn"` rather than `"error"` for the new categories avoids making every new category a blocker immediately. They can be promoted to `"error"` once the codebase is clean.
+
+---
+
+## Comparison
+
+|  | Option A (CI) | Option B (Husky) |
+|---|---|---|
+| New dependencies | None | `husky`, `lint-staged` |
+| Enforcement boundary | PR merge | Local commit |
+| Feedback speed | Slow (after push) | Fast (at commit) |
+| Bypassable | Only by force-merge | `git commit --no-verify` |
+| Setup required | None | `npm install` |
+| Works without GitHub | No | Yes |
+
+---
+
+## Recommendation
+
+**Option A (CI enforcement) is recommended** for this project. It requires no new dependencies, no local setup from contributors, and enforces linting at the most important boundary — the PR — without requiring anyone to remember to run anything. The slower feedback loop is acceptable given the single-developer workflow: running `npm run lint` before pushing is a low-friction habit, and the CI check acts as a backstop.
+
+**Option B (Husky)** is the better choice in a multi-contributor project where local enforcement prevents PRs from arriving already full of lint violations. For this project's current scale, the added dependency surface is not justified by the benefit.
+
+Regardless of which option is chosen, upgrading from `flat/essential` to `flat/recommended` for the Vue rules is worthwhile. The additional rules catch real authoring mistakes and the migration cost is low.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,7 +19,7 @@ export default defineConfigWithVueTs(
 
   globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
 
-  ...pluginVue.configs['flat/essential'],
+  ...pluginVue.configs['flat/recommended'],
   vueTsConfigs.recommended,
 
   {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
+    "lint:ci": "run-s lint:ci:*",
+    "lint:ci:oxlint": "oxlint .",
+    "lint:ci:eslint": "eslint .",
     "format": "prettier --write --experimental-cli src/"
   },
   "dependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@ const workspacesStore = useWorkspacesStore()
     <ItemEditorPanel v-model="userInterface.itemEditorOpen" :item-id="userInterface.editingItemId" />
     <ItemViewerPanel v-model="userInterface.itemViewerOpen" :item-id="userInterface.viewingItemId" />
     <WorkspaceEditorPanel v-model="userInterface.workspaceEditorOpen" :workspace-id="userInterface.editingWorkspaceId" />
-    <WorkspacesPanel v-model="userInterface.workspacesOpen" :workspaceIds="workspacesStore.workspaceIds" />
+    <WorkspacesPanel v-model="userInterface.workspacesOpen" :workspace-ids="workspacesStore.workspaceIds" />
     <SettingsPanel v-model="userInterface.settingsOpen" />
     <SpeedbumpDialog />
   </v-app>

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -6,7 +6,7 @@ const model = defineModel<DateRange>({
   default: makeDateRange
 })
 
-const props = defineProps<{
+defineProps<{
   hideDetails?: boolean | 'auto'
   rules?: ((value: DateRange) => string | boolean)[]
 }>()

--- a/src/components/backlog/BacklogList.vue
+++ b/src/components/backlog/BacklogList.vue
@@ -47,7 +47,7 @@ async function deleteItem(id: string) {
 </script>
 
 <template>
-  <v-data-table :headers="headers" :items="rows" item-value="id" @click:row="(_: Event, { item }: { item: { id: string } }) => userInterface.openItemViewer(item.id)" class="clickable-rows">
+  <v-data-table :headers="headers" :items="rows" item-value="id" class="clickable-rows" @click:row="(_: Event, { item }: { item: { id: string } }) => userInterface.openItemViewer(item.id)">
     <template #top>
       <v-btn prepend-icon="mdi-plus" variant="text" @click="createItem">New item</v-btn>
     </template>
@@ -64,7 +64,7 @@ async function deleteItem(id: string) {
       <DateChip :date="item.endDate" />
     </template>
     <template #item.workspaces="{ item }">
-      <WorkspaceChip v-for="wid in workspaceIdsFor(item.id)" :key="wid" :workspaceId="wid" class="mr-1" />
+      <WorkspaceChip v-for="wid in workspaceIdsFor(item.id)" :key="wid" :workspace-id="wid" class="mr-1" />
     </template>
     <template #item.actions="{ item }">
       <v-menu>

--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -92,10 +92,10 @@ const dateRangeRules = [ endDateAfterStart, rangeDatesValid ]
 <template>
   <v-navigation-drawer
     :model-value="model"
-    @update:model-value="val => { if (!val) cancel() }"
     temporary
     location="right"
     width="500"
+    @update:model-value="val => { if (!val) cancel() }"
   >
     <!-- HEADER -->
     <v-toolbar class="header" density="compact">

--- a/src/components/roadmap/RoadmapBar.vue
+++ b/src/components/roadmap/RoadmapBar.vue
@@ -35,8 +35,8 @@ function startEdgeDrag(event: MouseEvent, side: 'start' | 'end') {
     const current = itemsStore.getItem(props.id)
     if (side === 'start') {
       if (newDate < current.endDate) itemsStore.updateItem(props.id, { startDate: newDate })
-    } else {
-      if (newDate > current.startDate) itemsStore.updateItem(props.id, { endDate: newDate })
+    } else if (newDate > current.startDate) {
+      itemsStore.updateItem(props.id, { endDate: newDate })
     }
   }, { cursor: 'ew-resize' })
 }

--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -84,14 +84,14 @@ const bars = computed(() =>
 </script>
 
 <template>
-  <div class="roadmap-chart" ref="root">
+  <div ref="root" class="roadmap-chart">
     <svg
       :width="svgWidth"
       :height="svgHeight"
       xmlns="http://www.w3.org/2000/svg"
     >
       <!-- Vertical grid lines at each interval boundary -->
-      <SvgVerticalGridLines :intervalStarts="intervalStarts" :dateRange="dateRange" :scale="scale" :height="svgHeight" />
+      <SvgVerticalGridLines :interval-starts="intervalStarts" :date-range="dateRange" :scale="scale" :height="svgHeight" />
 
       <!--
         Horizontal row dividers matching the item list borders.
@@ -123,8 +123,8 @@ const bars = computed(() =>
       <!-- Item bars -->
       <RoadmapBar
         v-for="bar in bars"
-        :key="bar.id"
         :id="bar.id"
+        :key="bar.id"
         :x="bar.x"
         :y="bar.y"
         :width="bar.width"

--- a/src/components/roadmap/RoadmapHeader.vue
+++ b/src/components/roadmap/RoadmapHeader.vue
@@ -24,12 +24,12 @@ const svgHeight = ROW_HEIGHT * 2
 </script>
 
 <template>
-  <div class="roadmap-header" ref="root">
+  <div ref="root" class="roadmap-header">
     <svg
       :width="svgWidth"
       :height="svgHeight"
     >
-      <SvgVerticalGridLines :intervalStarts="intervalStarts" :dateRange="dateRange" :scale="scale" :height="svgHeight" />
+      <SvgVerticalGridLines :interval-starts="intervalStarts" :date-range="dateRange" :scale="scale" :height="svgHeight" />
       <text
         v-for="week in intervalStarts"
         :key="week.getTime()"

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -83,7 +83,7 @@ function startDrag(event: MouseEvent, itemId: string) {
     <div class="resize-handle" @mousedown="startResizeDrag" />
     <div v-if="itemIds.length === 0" class="empty-row">No items</div>
     <div
-      v-for="(itemId, index) in itemIds"
+      v-for="itemId in itemIds"
       :key="itemId"
       class="item-row"
       :class="{ 'drag-target': itemId === draggingItemId }"

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -31,7 +31,7 @@ const sortedItemIds = computed(() => {
   const ids = [...workspace.value.items]
   if (sortOption.value === 'custom') return ids
 
-  return ids.sort((a, b) => {
+  return ids.toSorted((a, b) => {
     let comparison = 0
     if (sortOption.value === 'name') {
       comparison = itemsStore.getName(a).localeCompare(itemsStore.getName(b))

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -48,7 +48,7 @@ async function newItem() {
             </template>
           </AddItemMenu>
         </div>
-        <RoadmapHeader :itemIds="workspace.items" />
+        <RoadmapHeader :item-ids="workspace.items" />
       </div>
 
       <!-- Body: Items List & Roadmap Render -->
@@ -57,7 +57,7 @@ async function newItem() {
         <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" />
 
         <!-- Roadmap Chart -->
-        <RoadmapChart class="chart" :itemIds="workspace.items" />
+        <RoadmapChart class="chart" :item-ids="workspace.items" />
       </div>
     </div>
   </div>

--- a/src/components/roadmap/SettingsPanel.vue
+++ b/src/components/roadmap/SettingsPanel.vue
@@ -53,11 +53,11 @@ async function reset() {
             <div class="text-caption text-medium-emphasis mb-1">Grid interval</div>
             <v-btn-toggle
               :model-value="userInterface.roadmapScale.gridInterval"
-              @update:model-value="updateGridInterval"
               mandatory
               variant="outlined"
               density="compact"
               divided
+              @update:model-value="updateGridInterval"
             >
               <v-btn
                 v-for="option in intervalOptions"
@@ -76,11 +76,11 @@ async function reset() {
             </div>
             <v-slider
               :model-value="userInterface.roadmapScale.pixelsPerDay"
-              @update:model-value="updatePixelsPerDay"
               :min="5"
               :max="100"
               :step="1"
               hide-details
+              @update:model-value="updatePixelsPerDay"
             />
           </div>
 
@@ -98,11 +98,11 @@ async function reset() {
             </div>
             <v-slider
               :model-value="userInterface.roadmapListWidth"
-              @update:model-value="userInterface.updateRoadmapListWidth"
               :min="MIN_LIST_WIDTH"
               :max="MAX_LIST_WIDTH"
               :step="1"
               hide-details
+              @update:model-value="userInterface.updateRoadmapListWidth"
             />
           </div>
         </v-card-text>

--- a/src/components/roadmap/constants.ts
+++ b/src/components/roadmap/constants.ts
@@ -15,7 +15,7 @@ export const LIST_WIDTH_PX = `${DEFAULT_LIST_WIDTH}px`
 export const LIST_BORDER_COLOR = BORDER_COLOR_LIGHT
 
 // Chart Values
-export const CHART_BAR_PADDING = 6 // Vertical space on top and bottom of roadmap bars
+export const CHART_BAR_PADDING = 6
 export const CHART_BORDER_COLOR_PRIMARY = BORDER_COLOR_LIGHT
 export const DEFAULT_PIXELS_PER_DAY = 30
 export const DEFAULT_INTERVAL = 'week'

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -93,9 +93,9 @@ const nameRules = [ required ]
 <template>
   <v-navigation-drawer
     :model-value="model"
-    @update:model-value="val => { if (!val) cancel() }"
     temporary
     width="500"
+    @update:model-value="val => { if (!val) cancel() }"
   >
     <!-- HEADER -->
     <v-toolbar class="header" density="compact">

--- a/src/components/workspaces/WorkspacesPanel.vue
+++ b/src/components/workspaces/WorkspacesPanel.vue
@@ -39,7 +39,7 @@ function addWorkspace() {
       <WorkspaceCard
         v-for="workspaceId in sortedWorkspaceIds"
         :key="workspaceId"
-        :workspaceId="workspaceId"
+        :workspace-id="workspaceId"
       />
 
       <v-card class="add-workspace-card" variant="outlined" @click="addWorkspace">

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -11,7 +11,7 @@ export const useInterfaceStore = defineStore('interface', () => {
   const defaultWorkspaceId = computed(() => {
     const workspacesStore = useWorkspacesStore()
 
-    if (!workspacesStore.hasWorkspaces) return undefined
+    if (!workspacesStore.hasWorkspaces) return
     if (
       favoriteWorkspaceId.value &&
       workspacesStore.doesWorkspaceExist(favoriteWorkspaceId.value)

--- a/src/stores/items.ts
+++ b/src/stores/items.ts
@@ -38,7 +38,7 @@ export const useItemsStore = defineStore('items', () => {
   }
 
   function getItems(ids: string[]): Item[] {
-    return ids.map(getItem)
+    return ids.map(id => getItem(id))
   }
 
   function getName(id: string): string {

--- a/src/testing/dummy-items.ts
+++ b/src/testing/dummy-items.ts
@@ -1,3 +1,4 @@
+// oxlint-disable max-lines
 import type { Item } from "@/types"
 
 export const items: Record<string, Item> = {
@@ -601,4 +602,4 @@ export const items: Record<string, Item> = {
     endDate: new Date('2026-02-26T00:00:00Z'),
     color: '#2ECC71',
   },
-};
+}

--- a/src/testing/dummy-workspaces.ts
+++ b/src/testing/dummy-workspaces.ts
@@ -1,3 +1,4 @@
+// oxlint-disable max-lines
 import type { Workspace } from "@/types"
 
 export const workspaces: Record<string, Workspace> = {
@@ -115,4 +116,4 @@ export const workspaces: Record<string, Workspace> = {
       'i-e5f6a7b8-c9d0-4234-8fab-345678901234',
     ],
   },
-};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,8 @@ export interface Workspace {
   name: string;
   description: string;
   color: string;
-  items: string[]; // List of item IDs
+  // List of item IDs
+  items: string[];
 }
 
 export function constructEmptyWorkspace(): Workspace {

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -18,11 +18,17 @@ export function validateColor(color: string) {
 // === HELPERS ===
 
 /**
+ * Screen colors are "gamma encoded" - darks are stretched out so they look smoother to human eyes.
+ * Before measuring how bright a color actually is, we need to undo that stretching.
+ * This converts a 0-1 channel value from "how it looks on screen" to "how much light it actually emits".
+ */
+const toLinear = (c: number) => c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+
+/**
  * Returns true if the given hex color is light enough to risk blending into
  * a light background. Uses WCAG relative luminance.
  */
 export function isLightColor(hex: string): boolean {
-  const toLinear = (c: number) => c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
   const r = toLinear(parseInt(hex.slice(1, 3), 16) / 255)
   const g = toLinear(parseInt(hex.slice(3, 5), 16) / 255)
   const b = toLinear(parseInt(hex.slice(5, 7), 16) / 255)

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -70,7 +70,8 @@ function ordinalSuffix(day: number): string {
 export function formatDate(date: string | number | Date, style: DateStyle) {
   const d = new Date(date)
   const year = d.getUTCFullYear()
-  const month = d.getUTCMonth() // 0-indexed
+  // Months 0-indexed
+  const month = d.getUTCMonth()
   const day = d.getUTCDate()
 
   const monthNames = [

--- a/src/views/ItemsView.vue
+++ b/src/views/ItemsView.vue
@@ -15,7 +15,7 @@ const itemsStore = useItemsStore()
         </div>
       </div>
 
-      <BacklogList :itemIds="itemsStore.itemIds" />
+      <BacklogList :item-ids="itemsStore.itemIds" />
     </div>
   </v-main>
 </template>

--- a/src/views/TestView.vue
+++ b/src/views/TestView.vue
@@ -85,13 +85,13 @@ function loadDummyData() {
     </v-container>
 
     <div class="pane">
-      <RoadmapPane v-if="workspaceId" :workspaceId="workspaceId" />
+      <RoadmapPane v-if="workspaceId" :workspace-id="workspaceId" />
     </div>
 
     <ItemEditorPanel v-model="itemEditorOpen" />
-    <ItemViewerPanel v-if="test_item_id" v-model="itemViewerOpen" :itemId="test_item_id" />
+    <ItemViewerPanel v-if="test_item_id" v-model="itemViewerOpen" :item-id="test_item_id" />
     <WorkspaceEditorPanel v-model="workspaceEditorOpen" />
-    <WorkspacesPanel v-model="workspacesOpen" :workspaceIds="workspaceIds" />
+    <WorkspacesPanel v-model="workspacesOpen" :workspace-ids="workspaceIds" />
     <SpeedbumpDialog />
 
     <BacklogList :item-ids="itemsStore.itemIds" />

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -49,7 +49,7 @@ const workspaceName = computed(() => activeWorkspace.value ?
       </div>
 
       <div class="roadmap-container">
-        <RoadmapPane :workspaceId="activeWorkspace" />
+        <RoadmapPane :workspace-id="activeWorkspace" />
       </div>
     </div>
   </v-main>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,8 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

- Adds `docs/linting-proposal.md` comparing two approaches for enforcing linting: CI via GitHub Actions (Option A) and pre-commit hooks via Husky/lint-staged (Option B)
- Recommends Option A (CI enforcement) as the right fit for this project's single-developer workflow
- Covers optional ruleset expansion: upgrading Vue rules from `essential` to `recommended` and adding `suspicious`/`pedantic` oxlint categories

Closes #60

## Test plan

- [ ] Review the proposal document for accuracy and completeness
- [ ] Decide on preferred approach before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)