### PR TITLE
Resolve linting warnings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -34,5 +34,11 @@ export default defineConfigWithVueTs(
 
   ...pluginOxlint.buildFromOxlintConfigFile('.oxlintrc.json'),
 
+  {
+    rules: {
+      'vue/valid-v-slot': ['error', { allowModifiers: true }],
+    },
+  },
+
   skipFormatting,
 )

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { type DateRange, dateToShortISOString, makeDateRange } from '@/utils/dates'
 import { ref, useTemplateRef, watch } from 'vue'
+import { VInput } from 'vuetify/components';
 
 const model = defineModel<DateRange>({
   default: makeDateRange
@@ -11,10 +12,10 @@ defineProps<{
   rules?: ((value: DateRange) => string | boolean)[]
 }>()
 
-const inputRef = useTemplateRef('inputRef')
+const inputRef = useTemplateRef<VInput>('inputRef')
 const hasError = ref(false)
 
-watch(() => (inputRef.value as any)?.isValid, (isValid) => {
+watch(() => inputRef.value?.isValid, (isValid) => {
   hasError.value = isValid === false
 })
 

--- a/src/components/MarkdownRenderer.vue
+++ b/src/components/MarkdownRenderer.vue
@@ -10,6 +10,7 @@ const rendered = computed(() => renderMarkdown(props.content))
 </script>
 
 <template>
+  <!-- eslint-disable-next-line vue/no-v-html -->
   <div class="markdown-body" v-html="rendered" />
 </template>
 


### PR DESCRIPTION
## Summary

- Added `vue/valid-v-slot` rule with `allowModifiers: true` to ESLint config to support slot modifiers used by Vuetify components
- Fixed `DateRangePicker.vue`: added proper `VInput` type for `useTemplateRef`, removing the `as any` cast
- Suppressed intentional `vue/no-v-html` warning in `MarkdownRenderer.vue` with an inline disable comment

## Test plan

- [ ] Run `npm run lint` and verify no linting errors
- [ ] Verify `DateRangePicker` still validates correctly
- [ ] Verify `MarkdownRenderer` still renders markdown content

🤖 Generated with [Claude Code](https://claude.com/claude-code)