### PR TITLE
Fix GitHub Pages routing for direct URL navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,37 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chronicle</title>
+    <script>
+      // GitHub Pages SPA redirect handler
+      // Restores the path that was encoded in the query string by 404.html
+      // Based on https://github.com/rafgraph/spa-github-pages
+      (function() {
+        var redirect = sessionStorage.redirect;
+        delete sessionStorage.redirect;
+        if (redirect && redirect !== location.href) {
+          history.replaceState(null, null, redirect);
+          return;
+        }
+        var search = location.search;
+        if (search.indexOf('?p=') === 0 || search.indexOf('&p=') !== -1) {
+          var params = search.slice(1).split('&');
+          var path = '';
+          var query = '';
+          for (var i = 0; i < params.length; i++) {
+            if (params[i].slice(0, 2) === 'p=') {
+              path = params[i].slice(2).replace(/~and~/g, '&');
+            } else if (params[i].slice(0, 2) === 'q=') {
+              query = '?' + params[i].slice(2).replace(/~and~/g, '&');
+            }
+          }
+          if (path) {
+            history.replaceState(null, null,
+              location.pathname.slice(0, location.pathname.lastIndexOf('/')) + '/' + path + query + location.hash
+            );
+          }
+        }
+      }());
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Chronicle</title>
+    <script>
+      // GitHub Pages SPA redirect
+      // When GitHub Pages 404s, redirect to index.html with the path
+      // encoded in the query string so the app can restore it.
+      // Based on https://github.com/rafgraph/spa-github-pages
+      var segmentCount = 1; // Number of path segments in the base URL (/Chronicle/ = 1)
+      var location = window.location;
+      location.replace(
+        location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') +
+        location.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+        location.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+        (location.search ? '&q=' + location.search.slice(1).replace(/&/g, '~and~') : '') +
+        location.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `public/404.html` that GitHub Pages serves when a path doesn't match a file. It encodes the requested path in the query string and redirects to the app root.
- Adds a script in `index.html` that runs on load, reads the encoded path from the query string, and restores it via `history.replaceState` so Vue Router sees the correct route.

This is the standard SPA redirect technique for GitHub Pages and requires no changes to the router configuration.

## Test plan

- [ ] Build and deploy to GitHub Pages
- [ ] Navigate directly to `/Chronicle/items` — should load the items view
- [ ] Navigate directly to `/Chronicle/workspace/<id>` — should load the workspace (or redirect home if the id doesn't exist)
- [ ] Verify the root URL `/Chronicle/` still works normally

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)