### PR TITLE
Hotfix v0.5.1 — Fix double slash in GitHub Pages 404 redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chronicle",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chronicle",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "idb": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronicle",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/404.html
+++ b/public/404.html
@@ -12,7 +12,7 @@
       var location = window.location;
       location.replace(
         location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') +
-        location.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+        location.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=' +
         location.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
         (location.search ? '&q=' + location.search.slice(1).replace(/&/g, '~and~') : '') +
         location.hash


### PR DESCRIPTION
Closes #32

## Summary

- Fix extra `/` inserted by the 404 redirect page when reconstructing the URL for GitHub Pages SPA routing

## Root Cause

`404.html` encoded the path with a leading slash (`?p=/path`), then `index.html` prepended another `/` during reconstruction, resulting in double slashes (`/Chronicle//path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)