### PR TITLE
Fix missing roadmap hover effects

### DIFF
--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -41,6 +41,11 @@ import RoadmapBar from './RoadmapBar.vue'
 const props = defineProps<{
   /** Ordered list of roadmap item IDs to render, one row per item. */
   itemIds: string[]
+  hoveredItemId: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:hoveredItemId': [id: string | null]
 }>()
 
 const itemsStore = useItemsStore()
@@ -114,10 +119,22 @@ const showTodayLine = computed(() => todayX.value >= 0 && todayX.value <= svgWid
 
       <!-- Row hover backgrounds -->
       <rect
-        v-for="(_, index) in rowCount"
-        :key="`bg-${index}`"
+        v-for="(itemId, index) in itemIds"
+        :key="`bg-${itemId}`"
         x="0"
         :y="index * ROW_HEIGHT"
+        :width="svgWidth"
+        :height="ROW_HEIGHT"
+        :class="{ 'row-bg': true, 'row-hovered': itemId === hoveredItemId }"
+        @mouseenter="emit('update:hoveredItemId', itemId)"
+        @mouseleave="emit('update:hoveredItemId', null)"
+      />
+      <!-- Empty-state background row (no hover) -->
+      <rect
+        v-if="itemIds.length === 0"
+        key="bg-empty"
+        x="0"
+        y="0"
         :width="svgWidth"
         :height="ROW_HEIGHT"
         class="row-bg"
@@ -160,7 +177,8 @@ svg {
 .row-bg {
   fill: transparent;
 
-  &:hover {
+  &:hover,
+  &.row-hovered {
     fill: rgba(0, 0, 0, 0.04);
   }
 }

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -10,6 +10,11 @@ const props = defineProps<{
   workspaceId: string
   listWidth: number
   itemIds: string[]
+  hoveredItemId: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:hoveredItemId': [id: string | null]
 }>()
 
 const listWidthPx = computed(() => `${props.listWidth}px`)
@@ -86,7 +91,9 @@ function startDrag(event: MouseEvent, itemId: string) {
       v-for="itemId in itemIds"
       :key="itemId"
       class="item-row"
-      :class="{ 'drag-target': itemId === draggingItemId }"
+      :class="{ 'drag-target': itemId === draggingItemId, 'row-hovered': itemId === hoveredItemId }"
+      @mouseenter="emit('update:hoveredItemId', itemId)"
+      @mouseleave="emit('update:hoveredItemId', null)"
     >
       <template v-if="itemId !== draggingItemId">
         <div
@@ -224,7 +231,10 @@ function startDrag(event: MouseEvent, itemId: string) {
     }
   }
 
-  &:hover {
+  &:hover,
+  &.row-hovered {
+    background-color: rgba(0, 0, 0, 0.04);
+
     .move-buttons,
     .drag-bar,
     .settings-button {

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -3,7 +3,7 @@ import RoadmapItemList from './RoadmapItemList.vue'
 import { PANE_COLOR_PRIMARY, ROW_HEIGHT_PX, SECTION_BORDER_COLOR } from './constants'
 import RoadmapChart from './RoadmapChart.vue'
 import RoadmapHeader from './RoadmapHeader.vue'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useWorkspacesStore } from '@/stores/workspaces'
 import { useInterfaceStore } from '@/stores/interface'
@@ -53,6 +53,8 @@ async function newItem() {
   if (itemId) workspacesStore.updateWorkspace(props.workspaceId, { items: [...workspace.value.items, itemId] })
 }
 
+const hoveredItemId = ref<string | null>(null)
+
 </script>
 
 <template>
@@ -75,10 +77,10 @@ async function newItem() {
       <!-- Body: Items List & Roadmap Render -->
       <div class="body">
         <!-- Item List -->
-        <RoadmapItemList class="item-list" :workspace-id="workspaceId" :list-width="listWidth" :item-ids="sortedItemIds" />
+        <RoadmapItemList v-model:hovered-item-id="hoveredItemId" class="item-list" :workspace-id="workspaceId" :list-width="listWidth" :item-ids="sortedItemIds" />
 
         <!-- Roadmap Chart -->
-        <RoadmapChart class="chart" :item-ids="sortedItemIds" />
+        <RoadmapChart v-model:hovered-item-id="hoveredItemId" class="chart" :item-ids="sortedItemIds" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Added a shared `hoveredItemId` ref in `RoadmapPane` coordinated between `RoadmapItemList` and `RoadmapChart` via `v-model`
- Hovering either the item list row or the chart row now highlights the full row on both sides with a background fill
- Action buttons (drag handle, settings) are now revealed when hovering from either side

Closes #34

## Test Plan

- [x] Open a workspace with roadmap items.
- [x] Hover over a row in the item list — confirm the corresponding row in the chart is also highlighted with a background fill.
- [x] Hover over a row in the chart — confirm the corresponding row in the item list is also highlighted with a background fill.
- [x] While hovering a row from either side, confirm the drag handle, move buttons, and settings button become visible.
- [x] Move the cursor off a row — confirm both sides return to their unhovered (transparent) state.
- [x] Confirm hovering one row and moving to another correctly transfers the highlight without any rows staying stuck in the hovered state.
- [x] Open a workspace with no roadmap items — confirm no errors occur and the empty-state chart row renders without issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)