### PR TITLE
Fix unreliable behavior with multiple tabs

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import type { Item, Workspace } from '@/types'
 import { toRaw } from 'vue'
 import type { RoadmapInterval } from '@/components/roadmap/roadmap-utils'
 import { DEFAULT_INTERVAL, DEFAULT_LIST_WIDTH, DEFAULT_PIXELS_PER_DAY } from '@/components/roadmap/constants'
+import { broadcastChange } from './sync'
 
 /**
  * Application-level settings persisted across sessions.
@@ -66,13 +67,16 @@ export async function getAllItems(): Promise<Record<string, Item>> {
  */
 export async function putItem(id: string, item: Item): Promise<void> {
   const db = await getDatabase()
-  await db.put('items', toRaw(item), id)
+  const raw = toRaw(item)
+  await db.put('items', raw, id)
+  broadcastChange({ type: 'put-item', id, item: raw })
 }
 
 /** Removes an item from the store by ID. */
 export async function removeItem(id: string): Promise<void> {
   const db = await getDatabase()
   await db.delete('items', id)
+  broadcastChange({ type: 'remove-item', id })
 }
 
 // === Workspaces ===
@@ -91,13 +95,16 @@ export async function getAllWorkspaces(): Promise<Record<string, Workspace>> {
  */
 export async function putWorkspace(id: string, workspace: Workspace): Promise<void> {
   const db = await getDatabase()
-  await db.put('workspaces', toRaw(workspace), id)
+  const raw = toRaw(workspace)
+  await db.put('workspaces', raw, id)
+  broadcastChange({ type: 'put-workspace', id, workspace: raw })
 }
 
 /** Removes a workspace from the store by ID. */
 export async function removeWorkspace(id: string): Promise<void> {
   const db = await getDatabase()
   await db.delete('workspaces', id)
+  broadcastChange({ type: 'remove-workspace', id })
 }
 
 // === Clear ===
@@ -137,5 +144,7 @@ export function makeDefaultSettings(): AppSettings {
 export async function putSettings(settings: Partial<AppSettings>): Promise<void> {
   const db = await getDatabase()
   const current = (await db.get('settings', 'app')) ?? makeDefaultSettings()
-  await db.put('settings', { ...current, ...settings }, 'app')
+  const merged = { ...current, ...settings }
+  await db.put('settings', merged, 'app')
+  broadcastChange({ type: 'put-settings', settings: merged })
 }

--- a/src/db/sync.ts
+++ b/src/db/sync.ts
@@ -1,0 +1,52 @@
+import type { Item, Workspace } from '@/types'
+import type { AppSettings } from './index'
+
+type SyncMessage =
+  | { type: 'put-item'; id: string; item: Item }
+  | { type: 'remove-item'; id: string }
+  | { type: 'put-workspace'; id: string; workspace: Workspace }
+  | { type: 'remove-workspace'; id: string }
+  | { type: 'put-settings'; settings: AppSettings }
+
+const channel = new BroadcastChannel('chronicle-sync')
+
+export function broadcastChange(message: SyncMessage): void {
+  // oxlint-disable-next-line unicorn/require-post-message-target-origin -- BroadcastChannel.postMessage takes no targetOrigin
+  channel.postMessage(message)
+}
+
+export interface SyncCallbacks {
+  onItemPut: (id: string, item: Item) => void
+  onItemRemove: (id: string) => void
+  onWorkspacePut: (id: string, workspace: Workspace) => void
+  onWorkspaceRemove: (id: string) => void
+  onSettingsPut: (settings: AppSettings) => void
+}
+
+/**
+ * Listens for cross-tab mutations broadcast by other Chronicle tabs and applies
+ * them to the in-memory store via the provided callbacks.  Must be called once
+ * after stores have been initialized.
+ */
+export function setupSync(callbacks: SyncCallbacks): void {
+  channel.addEventListener('message', (event: MessageEvent<SyncMessage>) => {
+    const message = event.data
+    switch (message.type) {
+      case 'put-item':
+        callbacks.onItemPut(message.id, message.item)
+        break
+      case 'remove-item':
+        callbacks.onItemRemove(message.id)
+        break
+      case 'put-workspace':
+        callbacks.onWorkspacePut(message.id, message.workspace)
+        break
+      case 'remove-workspace':
+        callbacks.onWorkspaceRemove(message.id)
+        break
+      case 'put-settings':
+        callbacks.onSettingsPut(message.settings)
+        break
+    }
+  })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,17 +9,30 @@ import vuetify from './plugins/vuetify'
 import { useWorkspacesStore } from './stores/workspaces'
 import { useItemsStore } from './stores/items'
 import { useInterfaceStore } from './stores/interface'
+import { setupSync } from './db/sync'
 
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(vuetify)
 
+const itemsStore = useItemsStore()
+const workspacesStore = useWorkspacesStore()
+const interfaceStore = useInterfaceStore()
+
 await Promise.all([
-  useWorkspacesStore().initializeWorkspaces(),
-  useItemsStore().initializeItems(),
-  useInterfaceStore().initializeInterface()
+  workspacesStore.initializeWorkspaces(),
+  itemsStore.initializeItems(),
+  interfaceStore.initializeInterface()
 ])
+
+setupSync({
+  onItemPut: (id, item) => itemsStore.applyExternalPut(id, item),
+  onItemRemove: (id) => itemsStore.applyExternalRemove(id),
+  onWorkspacePut: (id, workspace) => workspacesStore.applyExternalPut(id, workspace),
+  onWorkspaceRemove: (id) => workspacesStore.applyExternalRemove(id),
+  onSettingsPut: (settings) => interfaceStore.applyExternalSettings(settings),
+})
 
 app.use(router)
 app.mount('#app')

--- a/src/stores/interface/index.ts
+++ b/src/stores/interface/index.ts
@@ -31,7 +31,7 @@ export const useInterfaceStore = defineStore('interface', () => {
   const gridInterval = ref<RoadmapInterval>(DEFAULT_INTERVAL)
   const roadmapListWidth = ref<number>(DEFAULT_LIST_WIDTH)
 
-  const { initializeInterface, setFavoriteWorkspace } =
+  const { initializeInterface, setFavoriteWorkspace, applyExternalSettings } =
     useInterfaceInitialization(favoriteWorkspaceId, pixelsPerDay, gridInterval, roadmapListWidth)
   const { roadmapScale, roadmapListWidthPx, updateRoadmapScale, updateRoadmapListWidth } =
     useInterfaceRoadmap(pixelsPerDay, gridInterval, roadmapListWidth)
@@ -45,6 +45,7 @@ export const useInterfaceStore = defineStore('interface', () => {
     defaultWorkspaceId,
     initializeInterface,
     setFavoriteWorkspace,
+    applyExternalSettings,
     roadmapScale,
     roadmapListWidthPx,
     roadmapListWidth,

--- a/src/stores/interface/initialization.ts
+++ b/src/stores/interface/initialization.ts
@@ -1,4 +1,4 @@
-import { getSettings, makeDefaultSettings, putSettings } from "@/db"
+import { getSettings, makeDefaultSettings, putSettings, type AppSettings } from "@/db"
 import type { RoadmapInterval } from "@/components/roadmap/roadmap-utils"
 import type { Ref } from "vue"
 
@@ -22,5 +22,12 @@ export function useInterfaceInitialization(
     await putSettings({ favoriteWorkspaceId: id })
   }
 
-  return { initializeInterface, setFavoriteWorkspace }
+  function applyExternalSettings(settings: AppSettings) {
+    favoriteWorkspaceId.value = settings.favoriteWorkspaceId
+    pixelsPerDay.value = settings.pixelsPerDay
+    gridInterval.value = settings.gridInterval
+    roadmapListWidth.value = settings.roadmapListWidth
+  }
+
+  return { initializeInterface, setFavoriteWorkspace, applyExternalSettings }
 }

--- a/src/stores/items/index.ts
+++ b/src/stores/items/index.ts
@@ -17,6 +17,14 @@ export const useItemsStore = defineStore('items', () => {
   const { addItem, updateItem, deleteItem } =
     useItemsMutations(items, getItem, validateItemExists, getStartDate, getEndDate)
 
+  function applyExternalPut(id: string, item: Item) {
+    items.value[id] = item
+  }
+
+  function applyExternalRemove(id: string) {
+    delete items.value[id]
+  }
+
   return {
     itemIds,
     initializeItems,
@@ -30,6 +38,8 @@ export const useItemsStore = defineStore('items', () => {
     updateItem,
     doesItemExist,
     validateItemExists,
-    deleteItem
+    deleteItem,
+    applyExternalPut,
+    applyExternalRemove
   }
 })

--- a/src/stores/workspaces/index.ts
+++ b/src/stores/workspaces/index.ts
@@ -20,6 +20,14 @@ export const useWorkspacesStore = defineStore('workspaces', () => {
   const { moveItem, removeItemFromWorkspace } =
     useWorkspacesItemManagement(workspaces, getWorkspace, validateWorkspaceExists)
 
+  function applyExternalPut(id: string, workspace: Workspace) {
+    workspaces.value[id] = workspace
+  }
+
+  function applyExternalRemove(id: string) {
+    delete workspaces.value[id]
+  }
+
   return {
     workspaceIds,
     hasWorkspaces,
@@ -32,6 +40,8 @@ export const useWorkspacesStore = defineStore('workspaces', () => {
     updateWorkspace,
     deleteWorkspace,
     moveItem,
-    removeItemFromWorkspace
+    removeItemFromWorkspace,
+    applyExternalPut,
+    applyExternalRemove
   }
 })


### PR DESCRIPTION
## Summary

- Adds `src/db/sync.ts` which creates a `BroadcastChannel` and exposes `broadcastChange` and `setupSync`
- Every IndexedDB write (`putItem`, `removeItem`, `putWorkspace`, `removeWorkspace`, `putSettings`) now broadcasts the mutation to other open tabs
- Each store exposes `applyExternalPut`/`applyExternalRemove` (or `applyExternalSettings`) methods that update in-memory state without writing back to the DB
- `main.ts` calls `setupSync` after initialization to wire up the listeners

This ensures that when Tab A deletes an item, Tab B's store is immediately updated — preventing Tab B from writing a workspace with a dangling item reference back to IndexedDB, which was the root cause of the crash-on-load.

Closes #42

## Test Plan

- [x] Open the app in two tabs (Tab A and Tab B)
- [x] In Tab A, create a new item — verify Tab B reflects the new item without a page reload
- [x] In Tab A, update an existing item — verify Tab B shows the updated item
- [x] In Tab A, delete an item — verify Tab B removes the item immediately
- [x] In Tab A, create a new workspace — verify Tab B shows it
- [x] In Tab A, delete a workspace — verify Tab B removes it
- [x] In Tab A, change a setting (e.g. favorite workspace or roadmap scale) — verify Tab B reflects the change
- [x] **Bug regression**: In Tab B, add an item to a workspace. In Tab A, delete that item. Confirm Tab B's workspace no longer references the deleted item, and that reloading the app does not crash

https://claude.ai/code/session_0158iNBrS3jANKCe6y1xidvo