### PR TITLE
Prevent panels from being force-opened via edge swipe on mobile

### DIFF
--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -93,6 +93,7 @@ const dateRangeRules = [ endDateAfterStart, rangeDatesValid ]
   <v-navigation-drawer
     :model-value="model"
     temporary
+    touchless
     location="right"
     width="500"
     @update:model-value="val => { if (!val) cancel() }"

--- a/src/components/items/ItemViewerPanel.vue
+++ b/src/components/items/ItemViewerPanel.vue
@@ -26,7 +26,8 @@ const item = computed(
   <v-navigation-drawer
     v-if="item"
     v-model="model"
-    temporary 
+    temporary
+    touchless
     location="right"
     width="500"
   >

--- a/src/components/roadmap/SettingsPanel.vue
+++ b/src/components/roadmap/SettingsPanel.vue
@@ -32,6 +32,7 @@ async function reset() {
   <v-navigation-drawer
     v-model="model"
     temporary
+    touchless
     location="right"
     width="400"
   >

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -94,6 +94,7 @@ const nameRules = [ required ]
   <v-navigation-drawer
     :model-value="model"
     temporary
+    touchless
     width="500"
     @update:model-value="val => { if (!val) cancel() }"
   >

--- a/src/components/workspaces/WorkspacesPanel.vue
+++ b/src/components/workspaces/WorkspacesPanel.vue
@@ -26,6 +26,7 @@ function addWorkspace() {
   <v-navigation-drawer
     v-model="model"
     temporary
+    touchless
     width="500"
   >
     <!-- HEADER -->


### PR DESCRIPTION
## Summary

- Adds the `touchless` prop to all five `v-navigation-drawer` panel components (ItemEditorPanel, ItemViewerPanel, SettingsPanel, WorkspacesPanel, WorkspaceEditorPanel)
- This disables Vuetify's built-in swipe-from-edge gesture that was allowing panels to be force-opened on mobile devices
- Panels are only meant to be opened programmatically, so touch-swipe open should not be possible

## Test plan

- [ ] On a mobile device (or browser devtools mobile emulation), swipe from the left edge of the screen — WorkspacesPanel should not open
- [ ] Swipe from the right edge of the screen — ItemEditorPanel, ItemViewerPanel, SettingsPanel, WorkspaceEditorPanel should not open
- [ ] Verify panels still open and close correctly when triggered via their normal UI buttons

closes #80

https://claude.ai/code/session_01VTHfongkUTRG5GNXTR1vXr