### PR TITLE
Simpler cross-tab sync via BroadcastChannel

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import type { Item, Workspace } from '@/types'
 import { toRaw } from 'vue'
 import type { RoadmapInterval } from '@/components/roadmap/roadmap-utils'
 import { DEFAULT_INTERVAL, DEFAULT_LIST_WIDTH, DEFAULT_PIXELS_PER_DAY } from '@/components/roadmap/constants'
+import { broadcastChange } from './sync'
 
 /**
  * Application-level settings persisted across sessions.
@@ -67,12 +68,14 @@ export async function getAllItems(): Promise<Record<string, Item>> {
 export async function putItem(id: string, item: Item): Promise<void> {
   const db = await getDatabase()
   await db.put('items', toRaw(item), id)
+  broadcastChange()
 }
 
 /** Removes an item from the store by ID. */
 export async function removeItem(id: string): Promise<void> {
   const db = await getDatabase()
   await db.delete('items', id)
+  broadcastChange()
 }
 
 // === Workspaces ===
@@ -92,12 +95,14 @@ export async function getAllWorkspaces(): Promise<Record<string, Workspace>> {
 export async function putWorkspace(id: string, workspace: Workspace): Promise<void> {
   const db = await getDatabase()
   await db.put('workspaces', toRaw(workspace), id)
+  broadcastChange()
 }
 
 /** Removes a workspace from the store by ID. */
 export async function removeWorkspace(id: string): Promise<void> {
   const db = await getDatabase()
   await db.delete('workspaces', id)
+  broadcastChange()
 }
 
 // === Clear ===
@@ -138,4 +143,5 @@ export async function putSettings(settings: Partial<AppSettings>): Promise<void>
   const db = await getDatabase()
   const current = (await db.get('settings', 'app')) ?? makeDefaultSettings()
   await db.put('settings', { ...current, ...settings }, 'app')
+  broadcastChange()
 }

--- a/src/db/sync.ts
+++ b/src/db/sync.ts
@@ -1,0 +1,10 @@
+const channel = new BroadcastChannel('chronicle-sync')
+
+export function broadcastChange(): void {
+  // oxlint-disable-next-line unicorn/require-post-message-target-origin -- BroadcastChannel.postMessage takes no targetOrigin
+  channel.postMessage(null)
+}
+
+export function setupSync(onExternalChange: () => void): void {
+  channel.addEventListener('message', onExternalChange)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,17 +9,28 @@ import vuetify from './plugins/vuetify'
 import { useWorkspacesStore } from './stores/workspaces'
 import { useItemsStore } from './stores/items'
 import { useInterfaceStore } from './stores/interface'
+import { setupSync } from './db/sync'
 
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(vuetify)
 
-await Promise.all([
-  useWorkspacesStore().initializeWorkspaces(),
-  useItemsStore().initializeItems(),
-  useInterfaceStore().initializeInterface()
-])
+const workspacesStore = useWorkspacesStore()
+const itemsStore = useItemsStore()
+const interfaceStore = useInterfaceStore()
+
+async function initializeStores() {
+  await Promise.all([
+    workspacesStore.initializeWorkspaces(),
+    itemsStore.initializeItems(),
+    interfaceStore.initializeInterface()
+  ])
+}
+
+await initializeStores()
+
+setupSync(() => { void initializeStores() })
 
 app.use(router)
 app.mount('#app')

--- a/src/stores/items/initialization.ts
+++ b/src/stores/items/initialization.ts
@@ -4,8 +4,7 @@ import type { Ref } from "vue"
 
 export function useItemsInitialization(items: Ref<Record<string, Item>>) {
   async function initializeItems() {
-    const storedItems = await getAllItems()
-    Object.entries(storedItems).forEach(([id, item]) => items.value[id] = item)
+    items.value = await getAllItems()
   }
 
   return { initializeItems }

--- a/src/stores/workspaces/initialization.ts
+++ b/src/stores/workspaces/initialization.ts
@@ -4,10 +4,7 @@ import type { Ref } from "vue"
 
 export function useWorkspacesInitialization(workspaces: Ref<Record<string, Workspace>>) {
   async function initializeWorkspaces() {
-    const storedWorkspaces = await getAllWorkspaces()
-    Object.entries(storedWorkspaces).forEach(([id, workspace]) => {
-      workspaces.value[id] = workspace
-    })
+    workspaces.value = await getAllWorkspaces()
   }
 
   return { initializeWorkspaces }


### PR DESCRIPTION
## Summary

- Adds `src/db/sync.ts` with a single generic `BroadcastChannel` signal — no typed message union, no per-mutation callbacks
- Every IndexedDB write calls `broadcastChange()` (one line, no other changes required)
- `setupSync` in `main.ts` re-runs the existing `initializeStores()` function when a signal arrives, fully replacing in-memory state from IndexedDB
- `initializeWorkspaces` and `initializeItems` simplified to replace state wholesale (`workspaces.value = ...`) so re-initialization correctly handles deletes, not just puts

The key difference from PR #79: other tabs re-read from IndexedDB rather than receiving a data delta. This means adding a new DB mutation in the future requires only the one `broadcastChange()` call — no new message type, no new `applyExternal*` method on the store.

Closes #42

## Test Plan

- [ ] Open the app in two tabs (Tab A and Tab B)
- [ ] In Tab A, create a new item — verify Tab B reflects it without a page reload
- [ ] In Tab A, update an existing item — verify Tab B shows the update
- [ ] In Tab A, delete an item — verify Tab B removes it
- [ ] In Tab A, create a new workspace — verify Tab B shows it
- [ ] In Tab A, delete a workspace — verify Tab B removes it
- [ ] In Tab A, change a setting — verify Tab B reflects it
- [ ] **Bug regression**: In Tab B, add an item to a workspace. In Tab A, delete that item. Confirm Tab B no longer references the deleted item and reloading does not crash

https://claude.ai/code/session_01QvWDEDMGFAZxUZyW4ECcLf