### PR TITLE
Enable Vue devtools in preview builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     vue(),
     vueJsx()
@@ -15,5 +15,8 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-  base: '/Chronicle/'
-})
+  base: '/Chronicle/',
+  define: {
+    __VUE_PROD_DEVTOOLS__: mode === 'preview',
+  },
+}))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,9 @@
 import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
-import viteConfig from './vite.config'
+import viteConfigFn from './vite.config'
 
 export default mergeConfig(
-  viteConfig,
+  viteConfigFn({ mode: 'test', command: 'serve', isSsrBuild: false, isPreview: false }),
   defineConfig({
     test: {
       environment: 'jsdom',


### PR DESCRIPTION
Closes #84

## Summary

- Updated `vite.config.ts` to use the function form of `defineConfig` so the Vite `mode` is available.
- Set `__VUE_PROD_DEVTOOLS__: true` when `mode === 'preview'`, which tells Vue 3 to keep devtools support enabled in the preview build.

## Test plan

- [ ] Trigger a PR preview build and verify the Vue devtools browser extension connects to the app successfully.
- [ ] Verify a normal production build (`npm run build`) does not have devtools enabled (the define evaluates to `false`).

https://claude.ai/code/session_01LX3aCjHa877L8EMYks6i9r