### PR TITLE
Add file header documentation comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,5 @@ Instructions for Claude agents.
 - Unless a pull request exclusively adds documentation, you should always include a test plan.
 - You should make pull requests as drafts.
 - If necessary, update `ARCHITECTURE.md` when making a PR.
+- When making new files in `src/` be sure to include a header comment at the top of the file explaining its purpose.
+- When modifying files in `src/` be sure to update the header comment if neccesary.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,4 @@
+<!-- Root application shell: renders the app bar, router view, and all global overlay panels (editors, speedbump). -->
 <script setup lang="ts">
 import { RouterView, useRouter } from 'vue-router'
 import { useInterfaceStore } from './stores/interface'

--- a/src/SpeedbumpDialog.vue
+++ b/src/SpeedbumpDialog.vue
@@ -1,3 +1,4 @@
+<!-- Modal confirmation dialog driven by the interface store's speedbump state; resolves a promise on confirm or cancel. -->
 <script setup lang="ts">
 import { useInterfaceStore } from '@/stores/interface'
 

--- a/src/components/ColorSwatch.vue
+++ b/src/components/ColorSwatch.vue
@@ -1,3 +1,4 @@
+<!-- Renders a small square swatch filled with the given hex color. -->
 <script setup lang="ts">
 defineProps<{
   color: string

--- a/src/components/DateChip.vue
+++ b/src/components/DateChip.vue
@@ -1,3 +1,4 @@
+<!-- Displays a formatted date alongside a calendar icon, with a configurable DateStyle. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { formatDate, type DateStyle } from '@/utils/dates'

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -1,3 +1,4 @@
+<!-- Two-field date range picker (start + end) that binds to a DateRange model and supports Vuetify validation rules. -->
 <script setup lang="ts">
 import { type DateRange, dateToShortISOString, makeDateRange } from '@/utils/dates'
 import { ref, useTemplateRef, watch } from 'vue'

--- a/src/components/MarkdownRenderer.vue
+++ b/src/components/MarkdownRenderer.vue
@@ -1,3 +1,4 @@
+<!-- Renders a Markdown string as styled HTML using markdown-it, with scoped typography styles. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { renderMarkdown } from '@/utils/markdown'

--- a/src/components/backlog/BacklogList.vue
+++ b/src/components/backlog/BacklogList.vue
@@ -1,3 +1,4 @@
+<!-- Sortable data table of all items with color, dates, workspace chips, and inline edit/delete actions. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useItemsStore } from '@/stores/items'

--- a/src/components/items/AddItemMenu.vue
+++ b/src/components/items/AddItemMenu.vue
@@ -1,3 +1,4 @@
+<!-- Dropdown menu for adding an existing item or creating a new one, excluding already-added item IDs. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useItemsStore } from '@/stores/items'

--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -1,3 +1,4 @@
+<!-- Right-side drawer panel for creating or editing an item's details, schedule, color, and workspace memberships. -->
 <script setup lang="ts">
 import { areItemsEqual, constructEmptyItem, generateItemId, type Item } from '@/types'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'

--- a/src/components/items/ItemList.vue
+++ b/src/components/items/ItemList.vue
@@ -1,3 +1,4 @@
+<!-- Scrollable list of items with optional edit mode (reorder, remove, add) and a "view more/less" collapse. -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import ColorSwatch from '@/components/ColorSwatch.vue'

--- a/src/components/items/ItemRow.vue
+++ b/src/components/items/ItemRow.vue
@@ -1,3 +1,4 @@
+<!-- Renders a single item as a compact row showing its color swatch and name. -->
 <script setup lang="ts">
 import ColorSwatch from '@/components/ColorSwatch.vue'
 import type { Item } from '@/types'

--- a/src/components/items/ItemViewerPanel.vue
+++ b/src/components/items/ItemViewerPanel.vue
@@ -1,3 +1,4 @@
+<!-- Right-side drawer panel for viewing an item's details, schedule, color, and workspace memberships in read-only mode. -->
 <script setup lang="ts">
 import DateChip from '@/components/DateChip.vue'
 import MarkdownRenderer from '@/components/MarkdownRenderer.vue'

--- a/src/components/roadmap/RoadmapBar.vue
+++ b/src/components/roadmap/RoadmapBar.vue
@@ -1,3 +1,4 @@
+<!-- Renders a single Gantt bar with left/right edge drag handles that update the item's start and end dates. -->
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { CHART_BAR_PADDING, ROW_HEIGHT } from './constants'

--- a/src/components/roadmap/RoadmapChart.vue
+++ b/src/components/roadmap/RoadmapChart.vue
@@ -1,3 +1,4 @@
+<!-- SVG Gantt chart that renders colored bars for each item on a shared timeline with grid lines and a today marker. -->
 <script setup lang="ts">
 /**
  * RoadmapChart

--- a/src/components/roadmap/RoadmapHeader.vue
+++ b/src/components/roadmap/RoadmapHeader.vue
@@ -1,3 +1,4 @@
+<!-- SVG timeline header that draws interval labels, vertical grid lines, and a "Today" marker above the roadmap chart. -->
 <script setup lang="ts">
 import { computed, toRef, useTemplateRef } from 'vue'
 import { storeToRefs } from 'pinia'

--- a/src/components/roadmap/RoadmapItemList.vue
+++ b/src/components/roadmap/RoadmapItemList.vue
@@ -1,3 +1,4 @@
+<!-- Sticky left-side item list for the roadmap with drag-to-reorder, a resize handle, and row hover sync with the chart. -->
 <script setup lang="ts">
 import { useItemsStore } from '@/stores/items'
 import { useInterfaceStore } from '@/stores/interface'

--- a/src/components/roadmap/RoadmapPane.vue
+++ b/src/components/roadmap/RoadmapPane.vue
@@ -1,3 +1,4 @@
+<!-- Top-level roadmap layout: sticky header with timeline, scrollable item list and chart body, and an add-item menu. -->
 <script setup lang="ts">
 import RoadmapItemList from './RoadmapItemList.vue'
 import { PANE_COLOR_PRIMARY, ROW_HEIGHT_PX, SECTION_BORDER_COLOR } from './constants'

--- a/src/components/roadmap/SettingsPanel.vue
+++ b/src/components/roadmap/SettingsPanel.vue
@@ -1,3 +1,4 @@
+<!-- Right-side drawer for configuring roadmap display settings: grid interval, zoom level, and item list width. -->
 <script setup lang="ts">
 import { useInterfaceStore } from '@/stores/interface'
 import type { RoadmapInterval } from '@/components/roadmap/roadmap-utils'

--- a/src/components/roadmap/SvgVerticalGridLines.vue
+++ b/src/components/roadmap/SvgVerticalGridLines.vue
@@ -1,3 +1,4 @@
+<!-- Renders SVG vertical lines at each interval boundary across the full height of the roadmap SVG canvas. -->
 <script setup lang="ts">
 import { type DateRange } from '@/utils/dates'
 import { xForDate, type RoadmapScale } from './roadmap-utils'

--- a/src/components/roadmap/constants.ts
+++ b/src/components/roadmap/constants.ts
@@ -1,3 +1,4 @@
+// Shared layout and styling constants for the roadmap pane, item list, and chart (dimensions, colors, defaults).
 // Shared Values
 export const ROW_HEIGHT = 30
 export const ROW_HEIGHT_PX = `${ROW_HEIGHT}px`

--- a/src/components/roadmap/roadmap-utils.ts
+++ b/src/components/roadmap/roadmap-utils.ts
@@ -1,3 +1,4 @@
+// Roadmap type definitions, date-range and interval computation helpers, and the xForDate coordinate conversion function.
 import type { Item } from '@/types'
 import { MSEC_IN_DAY, type DateRange } from '@/utils/dates'
 

--- a/src/components/roadmap/useContainerWidth.ts
+++ b/src/components/roadmap/useContainerWidth.ts
@@ -1,3 +1,4 @@
+// Composable that tracks a DOM element's content width reactively via ResizeObserver.
 import { onBeforeUnmount, onMounted, ref, type Ref } from 'vue'
 
 /**

--- a/src/components/roadmap/useDragGesture.ts
+++ b/src/components/roadmap/useDragGesture.ts
@@ -1,3 +1,4 @@
+// Utility that attaches document-level mousemove/mouseup listeners to manage a drag gesture with cursor override and cleanup.
 /**
  * Initiates a mouse drag gesture from a mousedown event.
  *

--- a/src/components/roadmap/useRoadmapTimeline.ts
+++ b/src/components/roadmap/useRoadmapTimeline.ts
@@ -1,3 +1,4 @@
+// Composable that derives dateRange, svgWidth, and intervalStarts for roadmap SVG components based on item dates and container width.
 import { computed, type Ref } from 'vue'
 import { computeDateRange, computeDaysInRange, computeIntervalStarts } from './roadmap-utils'
 import { useItemsStore } from '@/stores/items'

--- a/src/components/workspaces/WorkspaceCard.vue
+++ b/src/components/workspaces/WorkspaceCard.vue
@@ -1,3 +1,4 @@
+<!-- Card displaying a workspace's name, description, and item list with hover actions to edit, open, or toggle as favorite. -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'

--- a/src/components/workspaces/WorkspaceChip.vue
+++ b/src/components/workspaces/WorkspaceChip.vue
@@ -1,3 +1,4 @@
+<!-- Renders a small colored chip for a workspace, adding a subtle border when the workspace color is very light. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useWorkspacesStore } from '@/stores/workspaces'

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -1,3 +1,4 @@
+<!-- Right-side drawer panel for creating or editing a workspace's name, description, color, and item list. -->
 <script setup lang="ts">
 import {
   areWorkspacesEqual,

--- a/src/components/workspaces/WorkspacesPanel.vue
+++ b/src/components/workspaces/WorkspacesPanel.vue
@@ -1,3 +1,4 @@
+<!-- Right-side drawer listing all workspace cards sorted with the favorite first, plus a button to create a new workspace. -->
 <script setup lang="ts">
 import { computed } from 'vue'
 import WorkspaceCard from './WorkspaceCard.vue'

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,3 +1,4 @@
+// IndexedDB persistence layer: opens and caches the Chronicle database and exposes CRUD helpers for items, workspaces, and settings.
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import type { Item, Workspace } from '@/types'
 import { toRaw } from 'vue'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+// Application entry point: creates the Vue app, initializes Pinia stores from IndexedDB, and mounts to #app.
 import './assets/main.css'
 
 import { createApp } from 'vue'

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,3 +1,4 @@
+// Configures and exports the Vuetify plugin instance with all components, directives, MDI icons, and the default light theme.
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,3 +1,4 @@
+// Defines application routes (home, workspace, items, and dev-only test) and guards against navigating to deleted workspaces.
 import { createRouter, createWebHistory } from 'vue-router'
 import WorkspacesView from '../views/WorkspacesView.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'

--- a/src/stores/interface/index.ts
+++ b/src/stores/interface/index.ts
@@ -1,3 +1,4 @@
+// Pinia store for UI state: composes roadmap scale, sorting, panel visibility, item panels, speedbump, and settings persistence.
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import {

--- a/src/stores/interface/initialization.ts
+++ b/src/stores/interface/initialization.ts
@@ -1,3 +1,4 @@
+// Loads persisted app settings into the interface store on startup and exposes setFavoriteWorkspace.
 import { getSettings, makeDefaultSettings, putSettings } from '@/db'
 import type { RoadmapInterval } from '@/components/roadmap/roadmap-utils'
 import type { Ref } from 'vue'

--- a/src/stores/interface/item-panels.ts
+++ b/src/stores/interface/item-panels.ts
@@ -1,3 +1,4 @@
+// Manages open/close state and active item ID for the item viewer, item editor, and item creator panels.
 import { ref } from 'vue'
 
 export function useInterfaceItemPanels() {

--- a/src/stores/interface/panels.ts
+++ b/src/stores/interface/panels.ts
@@ -1,3 +1,4 @@
+// Manages open/close state and editing context for the settings, workspaces, and workspace editor panels.
 import { ref } from 'vue'
 
 export function useInterfacePanels() {

--- a/src/stores/interface/roadmap.ts
+++ b/src/stores/interface/roadmap.ts
@@ -1,3 +1,4 @@
+// Derives reactive roadmap scale and list-width state and persists updates to IndexedDB via the interface store.
 import { putSettings } from '@/db'
 import type { RoadmapInterval, RoadmapScale } from '@/components/roadmap/roadmap-utils'
 import type { Ref } from 'vue'

--- a/src/stores/interface/sorting.ts
+++ b/src/stores/interface/sorting.ts
@@ -1,3 +1,4 @@
+// Manages the active sort option and sort direction for item lists in the interface store.
 import { ref, computed } from 'vue'
 
 export type SortOption = 'custom' | 'startDate' | 'endDate' | 'name'

--- a/src/stores/interface/speedbump.ts
+++ b/src/stores/interface/speedbump.ts
@@ -1,3 +1,4 @@
+// Provides a promise-based confirm() helper that shows a blocking speedbump dialog and resolves with the user's choice.
 import { ref } from 'vue'
 
 export function useInterfaceSpeedbump() {

--- a/src/stores/items/accessors.ts
+++ b/src/stores/items/accessors.ts
@@ -1,3 +1,4 @@
+// Provides read-only accessor functions (getItem, getName, getColor, getStartDate, getEndDate) for the items store.
 import type { Item } from '@/types'
 import type { Ref } from 'vue'
 

--- a/src/stores/items/index.ts
+++ b/src/stores/items/index.ts
@@ -1,3 +1,4 @@
+// Pinia store for items: composes validation, initialization, accessor, and mutation sub-modules into a single public API.
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { Item } from '@/types'

--- a/src/stores/items/initialization.ts
+++ b/src/stores/items/initialization.ts
@@ -1,3 +1,4 @@
+// Loads all persisted items from IndexedDB into the items store on startup.
 import { getAllItems } from '@/db'
 import type { Item } from '@/types'
 import type { Ref } from 'vue'

--- a/src/stores/items/mutations.ts
+++ b/src/stores/items/mutations.ts
@@ -1,3 +1,4 @@
+// Provides addItem, updateItem, and deleteItem mutations for the items store, with validation and DB persistence.
 import { putItem, removeItem } from '@/db'
 import { validateItemId, type Item } from '@/types'
 import { validateColor } from '@/utils/colors'

--- a/src/stores/items/validation.ts
+++ b/src/stores/items/validation.ts
@@ -1,3 +1,4 @@
+// Provides doesItemExist and validateItemExists helpers for the items store.
 import { isValidItemId, type Item } from '@/types'
 import type { Ref } from 'vue'
 

--- a/src/stores/workspaces/accessors.ts
+++ b/src/stores/workspaces/accessors.ts
@@ -1,3 +1,4 @@
+// Provides getWorkspace and getWorkspaceName read-only accessors for the workspaces store.
 import type { Workspace } from '@/types'
 import type { Ref } from 'vue'
 

--- a/src/stores/workspaces/index.ts
+++ b/src/stores/workspaces/index.ts
@@ -1,3 +1,4 @@
+// Pinia store for workspaces: composes validation, initialization, accessor, mutation, membership, and scrubbing sub-modules.
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { Workspace } from '@/types'

--- a/src/stores/workspaces/initialization.ts
+++ b/src/stores/workspaces/initialization.ts
@@ -1,3 +1,4 @@
+// Loads all persisted workspaces from IndexedDB into the workspaces store on startup.
 import { getAllWorkspaces } from '@/db'
 import type { Workspace } from '@/types'
 import type { Ref } from 'vue'

--- a/src/stores/workspaces/mutations.ts
+++ b/src/stores/workspaces/mutations.ts
@@ -1,3 +1,4 @@
+// Provides addWorkspace, updateWorkspace, and deleteWorkspace mutations for the workspaces store, with validation and DB persistence.
 import { putWorkspace, removeWorkspace } from '@/db'
 import { validateWorkspaceId, type Workspace } from '@/types'
 import { validateColor } from '@/utils/colors'

--- a/src/stores/workspaces/scrubbing.ts
+++ b/src/stores/workspaces/scrubbing.ts
@@ -1,3 +1,4 @@
+// Removes stale item IDs (referencing deleted items) from workspace item lists and persists the cleaned workspace.
 import { putWorkspace } from '@/db'
 import type { Workspace } from '@/types'
 import type { Ref } from 'vue'

--- a/src/stores/workspaces/validation.ts
+++ b/src/stores/workspaces/validation.ts
@@ -1,3 +1,4 @@
+// Provides doesWorkspaceExist and validateWorkspaceExists helpers for the workspaces store.
 import { isValidWorkspaceId, type Workspace } from '@/types'
 import type { Ref } from 'vue'
 

--- a/src/stores/workspaces/workspace-membership.ts
+++ b/src/stores/workspaces/workspace-membership.ts
@@ -1,3 +1,4 @@
+// Provides moveItem, addItemToWorkspace, and removeItemFromWorkspace operations for managing workspace item membership.
 import { putWorkspace } from '@/db'
 import type { Workspace } from '@/types'
 import type { Ref } from 'vue'

--- a/src/testing/dummy-items.ts
+++ b/src/testing/dummy-items.ts
@@ -1,3 +1,4 @@
+// Static fixture data: a large set of dummy Item records used for development and testing.
 // oxlint-disable max-lines
 import type { Item } from '@/types'
 

--- a/src/testing/dummy-workspaces.ts
+++ b/src/testing/dummy-workspaces.ts
@@ -1,3 +1,4 @@
+// Static fixture data: a set of dummy Workspace records referencing dummy items, used for development and testing.
 // oxlint-disable max-lines
 import type { Workspace } from '@/types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+// Defines core domain types (Workspace, Item) and their factory, equality, ID validation, and generation helpers.
 function randomColor(): string {
   return `#${Math.floor(Math.random() * 0xffffff)
     .toString(16)

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,3 +1,4 @@
+// Color validation helpers and a WCAG-based luminance check for determining whether a hex color is light or dark.
 // === VALIDATION ===
 
 const COLOR_REGEX = /^#[0-9a-f]{6}$/i

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,3 +1,4 @@
+// Date utility types, validation helpers, formatting functions, and constants used across the application.
 // === TYPES ===
 
 export type DateStyle = 'long-american' | 'short-american' | 'long-european' | 'short-european'

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,3 +1,4 @@
+// Wraps markdown-it to expose a single renderMarkdown(text) function that converts Markdown to HTML.
 import MarkdownIt from 'markdown-it'
 
 const md = new MarkdownIt()

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,4 @@
+// Vuetify form validation rules for required fields, hex colors, date strings, and date ranges.
 import { isValidColor } from './colors'
 import { isValidRange, type DateRange } from './dates'
 

--- a/src/views/ItemsView.vue
+++ b/src/views/ItemsView.vue
@@ -1,3 +1,4 @@
+<!-- Page view that lists all items in a flat backlog table, independent of any workspace. -->
 <script setup lang="ts">
 import BacklogList from '@/components/backlog/BacklogList.vue'
 import { useItemsStore } from '@/stores/items'

--- a/src/views/TestView.vue
+++ b/src/views/TestView.vue
@@ -1,3 +1,4 @@
+<!-- Development-only sandbox view for manually testing UI components and loading dummy data. -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import ItemEditorPanel from '@/components/items/ItemEditorPanel.vue'

--- a/src/views/WorkspacesView.vue
+++ b/src/views/WorkspacesView.vue
@@ -1,3 +1,4 @@
+<!-- Page view that displays the active workspace's roadmap, or an empty state when no workspaces exist. -->
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'


### PR DESCRIPTION
Adds a single-line documentation comment to the top of every `.vue` and `.ts` source file. The comment describes the file's role so its purpose is visible in `grep` results without needing to open the file.

Closes #90

## Test plan

- [ ] Verify every file in `src/` has a header comment that accurately describes its purpose
- [ ] Confirm `npm run lint` passes with no errors