### PR TITLE
Add random color generator utility and UI buttons

### DIFF
--- a/src/components/inputs/ColorInput.vue
+++ b/src/components/inputs/ColorInput.vue
@@ -1,0 +1,37 @@
+<!-- Color picker input with a random-color button, built on v-input. -->
+<script setup lang="ts">
+import { generateRandomColor } from '@/utils/colors'
+
+const model = defineModel<string>()
+
+defineProps<{
+  label?: string
+  variant?: 'outlined' | 'filled' | 'underlined' | 'solo' | 'solo-filled' | 'solo-inverted' | 'plain'
+  density?: 'default' | 'comfortable' | 'compact'
+  hideDetails?: boolean | 'auto'
+}>()
+</script>
+
+<template>
+  <v-input :model-value="model" :hide-details="hideDetails">
+    <template #default>
+      <div class="d-flex align-center ga-2 w-100">
+        <v-text-field
+          v-model="model"
+          :label="label"
+          :variant="variant"
+          :density="density"
+          type="color"
+          hide-details
+        />
+        <v-btn
+          icon="mdi-dice-multiple"
+          size="small"
+          variant="text"
+          title="Random color"
+          @click="model = generateRandomColor()"
+        />
+      </div>
+    </template>
+  </v-input>
+</template>

--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -8,7 +8,7 @@ import { makeDateRange, type DateRange } from '@/utils/dates'
 import { useInterfaceStore } from '@/stores/interface'
 import { endDateAfterStart, rangeDatesValid, required } from '@/utils/validation'
 import DateRangePicker from '../DateRangePicker.vue'
-import { generateRandomColor } from '@/utils/colors'
+import ColorInput from '../inputs/ColorInput.vue'
 
 // External State
 const model = defineModel<boolean>()
@@ -218,21 +218,13 @@ const dateRangeRules = [endDateAfterStart, rangeDatesValid]
           <v-card variant="outlined" height="100%">
             <v-card-title class="text-subtitle-2">Appearance</v-card-title>
             <v-divider />
-            <v-card-text class="d-flex align-center ga-2">
-              <v-text-field
+            <v-card-text>
+              <ColorInput
                 v-model="draft.color"
                 label="Color"
-                type="color"
                 variant="outlined"
                 density="compact"
                 hide-details="auto"
-              />
-              <v-btn
-                icon="mdi-dice-multiple"
-                size="small"
-                variant="text"
-                title="Random color"
-                @click="draft.color = generateRandomColor()"
               />
             </v-card-text>
           </v-card>

--- a/src/components/items/ItemEditorPanel.vue
+++ b/src/components/items/ItemEditorPanel.vue
@@ -8,6 +8,7 @@ import { makeDateRange, type DateRange } from '@/utils/dates'
 import { useInterfaceStore } from '@/stores/interface'
 import { endDateAfterStart, rangeDatesValid, required } from '@/utils/validation'
 import DateRangePicker from '../DateRangePicker.vue'
+import { generateRandomColor } from '@/utils/colors'
 
 // External State
 const model = defineModel<boolean>()
@@ -217,7 +218,7 @@ const dateRangeRules = [endDateAfterStart, rangeDatesValid]
           <v-card variant="outlined" height="100%">
             <v-card-title class="text-subtitle-2">Appearance</v-card-title>
             <v-divider />
-            <v-card-text>
+            <v-card-text class="d-flex align-center ga-2">
               <v-text-field
                 v-model="draft.color"
                 label="Color"
@@ -225,6 +226,13 @@ const dateRangeRules = [endDateAfterStart, rangeDatesValid]
                 variant="outlined"
                 density="compact"
                 hide-details="auto"
+              />
+              <v-btn
+                icon="mdi-dice-multiple"
+                size="small"
+                variant="text"
+                title="Random color"
+                @click="draft.color = generateRandomColor()"
               />
             </v-card-text>
           </v-card>

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -11,6 +11,7 @@ import ItemList from '../items/ItemList.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
 import { useInterfaceStore } from '@/stores/interface'
 import { required } from '@/utils/validation'
+import { generateRandomColor } from '@/utils/colors'
 
 // External state
 const model = defineModel<boolean>()
@@ -150,7 +151,7 @@ const nameRules = [required]
       <v-card variant="outlined">
         <v-card-title class="text-subtitle-2">Appearance</v-card-title>
         <v-divider />
-        <v-card-text>
+        <v-card-text class="d-flex align-center ga-2">
           <v-text-field
             v-model="draft.color"
             label="Color"
@@ -158,6 +159,13 @@ const nameRules = [required]
             variant="outlined"
             density="compact"
             hide-details="auto"
+          />
+          <v-btn
+            icon="mdi-dice-multiple"
+            size="small"
+            variant="text"
+            title="Random color"
+            @click="draft.color = generateRandomColor()"
           />
         </v-card-text>
       </v-card>

--- a/src/components/workspaces/WorkspaceEditorPanel.vue
+++ b/src/components/workspaces/WorkspaceEditorPanel.vue
@@ -11,7 +11,7 @@ import ItemList from '../items/ItemList.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
 import { useInterfaceStore } from '@/stores/interface'
 import { required } from '@/utils/validation'
-import { generateRandomColor } from '@/utils/colors'
+import ColorInput from '../inputs/ColorInput.vue'
 
 // External state
 const model = defineModel<boolean>()
@@ -151,21 +151,13 @@ const nameRules = [required]
       <v-card variant="outlined">
         <v-card-title class="text-subtitle-2">Appearance</v-card-title>
         <v-divider />
-        <v-card-text class="d-flex align-center ga-2">
-          <v-text-field
+        <v-card-text>
+          <ColorInput
             v-model="draft.color"
             label="Color"
-            type="color"
             variant="outlined"
             density="compact"
             hide-details="auto"
-          />
-          <v-btn
-            icon="mdi-dice-multiple"
-            size="small"
-            variant="text"
-            title="Random color"
-            @click="draft.color = generateRandomColor()"
           />
         </v-card-text>
       </v-card>

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,4 +1,4 @@
-// Color validation helpers and a WCAG-based luminance check for determining whether a hex color is light or dark.
+// Color validation helpers, a random color generator, and a WCAG-based luminance check for determining whether a hex color is light or dark.
 // === VALIDATION ===
 
 const COLOR_REGEX = /^#[0-9a-f]{6}$/i
@@ -13,6 +13,22 @@ export function validateColor(color: string) {
   if (!isValidColor(color)) {
     throw new Error(`Invalid hex color: "${color}"`)
   }
+}
+
+// === GENERATION ===
+
+/** Returns a random valid 6-digit hex color (e.g. `#a1b2c3`). */
+export function generateRandomColor(): string {
+  const r = Math.floor(Math.random() * 256)
+    .toString(16)
+    .padStart(2, '0')
+  const g = Math.floor(Math.random() * 256)
+    .toString(16)
+    .padStart(2, '0')
+  const b = Math.floor(Math.random() * 256)
+    .toString(16)
+    .padStart(2, '0')
+  return `#${r}${g}${b}`
 }
 
 // === HELPERS ===


### PR DESCRIPTION
## Summary
Added a new `generateRandomColor()` utility function to generate valid hex colors, and integrated it into the item and workspace editor panels with convenient "random color" buttons.

## Key Changes
- **New utility function**: Added `generateRandomColor()` to `src/utils/colors.ts` that generates random valid 6-digit hex colors (e.g., `#a1b2c3`)
- **ItemEditorPanel**: Added a dice button next to the color input field that generates a random color when clicked
- **WorkspaceEditorPanel**: Added the same dice button functionality for workspace color selection
- **Layout improvements**: Updated both editor panels to use flexbox layout (`d-flex align-center ga-2`) to properly align the color input and button

## Implementation Details
- The `generateRandomColor()` function generates three random bytes (0-255), converts them to hexadecimal, pads them to 2 digits, and combines them into a valid hex color string
- Both editor panels now import and use the new utility function
- The random color button uses the `mdi-dice-multiple` icon and includes a "Random color" tooltip for discoverability

https://claude.ai/code/session_01CVWKKZKsa8NNFzF4nJmBUF