### PR TITLE
Add /space/:spaceId route to router

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@ src/
 │
 ├── views/
 │   ├── WorkspacesView.vue      ← Main page: WorkspacesPanel + roadmap/backlog pane
+│   ├── SpaceView.vue           ← Space page: displays space data, visualizations, and workspaces
 │   ├── ItemsView.vue           ← Global items list (no workspace context)
 │   └── TestView.vue            ← Dev-only sandbox (only visible in dev/preview mode)
 │

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,8 @@
-// Defines application routes (home, workspace, items, and dev-only test) and guards against navigating to deleted workspaces.
+// Defines application routes (home, workspace, space, items, and dev-only test) and guards against navigating to deleted workspaces or spaces.
 import { createRouter, createWebHistory } from 'vue-router'
 import WorkspacesView from '../views/WorkspacesView.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
+import { useSpacesStore } from '@/stores/spaces'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -15,6 +16,11 @@ const router = createRouter({
       path: '/workspace/:workspaceId',
       name: 'workspace',
       component: WorkspacesView,
+    },
+    {
+      path: '/space/:spaceId',
+      name: 'space',
+      component: () => import('../views/SpaceView.vue'),
     },
     {
       path: '/items',
@@ -38,6 +44,13 @@ router.beforeEach((to) => {
     const workspaceId = to.params.workspaceId as string
     const workspacesStore = useWorkspacesStore()
     if (!workspacesStore.doesWorkspaceExist(workspaceId)) {
+      return { name: 'home' }
+    }
+  }
+  if (to.name === 'space') {
+    const spaceId = to.params.spaceId as string
+    const spacesStore = useSpacesStore()
+    if (!spacesStore.doesSpaceExist(spaceId)) {
       return { name: 'home' }
     }
   }

--- a/src/views/SpaceView.vue
+++ b/src/views/SpaceView.vue
@@ -68,7 +68,9 @@ const workspaces = computed(() =>
       </v-card>
 
       <v-card variant="outlined">
-        <v-card-title class="text-body-1">Visualizations ({{ visualizations.length }})</v-card-title>
+        <v-card-title class="text-body-1"
+          >Visualizations ({{ visualizations.length }})</v-card-title
+        >
         <v-card-text>
           <pre>{{ JSON.stringify(visualizations, null, 2) }}</pre>
         </v-card-text>

--- a/src/views/TestView.vue
+++ b/src/views/TestView.vue
@@ -13,6 +13,7 @@ import BacklogList from '@/components/backlog/BacklogList.vue'
 import { useItemsStore } from '@/stores/items'
 import { useVisualizationsStore } from '@/stores/visualizations'
 import { useSpacesStore } from '@/stores/spaces'
+import { useRouter } from 'vue-router'
 import { items as dummyItems } from '@/testing/dummy-items'
 import { workspaces as dummyWorkspaces } from '@/testing/dummy-workspaces'
 import { visualizations as dummyVisualizations } from '@/testing/dummy-visualizations'
@@ -24,6 +25,7 @@ const itemsStore = useItemsStore()
 const visualizationsStore = useVisualizationsStore()
 const spacesStore = useSpacesStore()
 const interfaceStore = useInterfaceStore()
+const router = useRouter()
 
 const test_item_id = computed(() => itemsStore.itemIds[0])
 
@@ -91,6 +93,9 @@ function loadDummyData() {
         </v-col>
         <v-col cols="auto">
           <v-btn @click="interfaceStore.revealSpeedBump('Are you sure?')">Speedbump</v-btn>
+        </v-col>
+        <v-col cols="auto">
+          <v-btn @click="router.push({ name: 'space', params: { spaceId: spacesStore.spaceIds[0] } })">First Space</v-btn>
         </v-col>
         <v-col cols="auto">
           <v-btn @click="loadDummyData">Load Dummy Data</v-btn>


### PR DESCRIPTION
Adds the `/space/:spaceId` route to the Vue Router using the `SpaceView` stub, with a navigation guard that redirects to home for invalid or non-existent space IDs.

closes #115

## Test plan

- [ ] Navigate to `/space/<valid-space-id>` — SpaceView loads and displays the space data
- [ ] Navigate to `/space/<nonexistent-id>` — redirects to home
- [ ] Delete a space while its route is open — redirects to home
- [ ] All existing routes (`/`, `/workspace/:id`, `/items`) still work normally

https://claude.ai/code/session_01NCAwKCtRiET5DJ5nxcYnU1