### PR TITLE
Spaces: Fix spaces and visualizations not loading from IndexedDB

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,7 +126,8 @@ Supporting files:
 
 | Task | Start here |
 |------|-----------|
-| Add a field to Item or Workspace | `src/types.ts`, then propagate to `src/db/index.ts` and the relevant store |
+| Add a field to Item or Workspace | `src/types/items.ts` or `src/types/workspaces.ts`, then propagate to `src/db/index.ts` and the relevant store |
+| Add a field to Space or Visualization | `src/types/spaces.ts` or `src/types/visualizations.ts`, then propagate to `src/db/index.ts` and the relevant store |
 | Add a new persisted setting | `AppSettings` in `src/db/index.ts`, `stores/interface/initialization.ts`, `stores/interface/roadmap.ts` or a new sub-module, `SettingsPanel.vue` |
 | Change how items are sorted | `src/stores/interface/sorting.ts` |
 | Add a route | `src/router/index.ts` |
@@ -134,8 +135,10 @@ Supporting files:
 | Change date/pixel math | `src/components/roadmap/roadmap-utils.ts` |
 | Add an item action (CRUD) | `src/stores/items/mutations.ts` |
 | Add a workspace action | `src/stores/workspaces/mutations.ts` or `workspace-membership.ts` |
+| Add a space action (CRUD) | `src/stores/spaces/mutations.ts` or `space-membership.ts` |
+| Add a visualization action (CRUD) | `src/stores/visualizations/mutations.ts` |
 | Add a confirmation dialog | `src/stores/interface/speedbump.ts` + `src/SpeedbumpDialog.vue` |
-| Add test fixtures | `src/testing/dummy-items.ts` or `dummy-workspaces.ts` |
+| Add test fixtures | `src/testing/` — `dummy-items.ts`, `dummy-workspaces.ts`, `dummy-spaces.ts`, or `dummy-visualizations.ts` |
 
 ## Validation convention
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,3 +152,4 @@ Two-function pattern used consistently:
 - The router validates that a workspace ID in the URL actually exists before navigating; invalid IDs redirect to `/`.
 - `WorkspacesView` is used for both `/` (no workspace selected) and `/workspace/:id` (workspace selected).
 - The TestView route is only shown in the nav when `import.meta.env.DEV || import.meta.env.MODE === 'preview'`.
+- Every store that persists to IndexedDB must have its `initialize*` function called in the `Promise.all` in `src/main.ts`. Omitting it means the store will always start empty after a page reload.

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,9 @@ app.use(vuetify)
 const workspacesStore = useWorkspacesStore()
 const spacesStore = useSpacesStore()
 
+// Every store that persists to IndexedDB must have its initialize function called here.
+// If a new store is added with an initialize* function, it belongs in this Promise.all.
+// Omitting it means the store will always start empty after a page reload (see issue #125).
 await Promise.all([
   workspacesStore.initializeWorkspaces(),
   useItemsStore().initializeItems(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import vuetify from './plugins/vuetify'
 import { useWorkspacesStore } from './stores/workspaces'
 import { useItemsStore } from './stores/items'
 import { useInterfaceStore } from './stores/interface'
+import { useSpacesStore } from './stores/spaces'
+import { useVisualizationsStore } from './stores/visualizations'
 
 const app = createApp(App)
 
@@ -17,14 +19,18 @@ app.use(createPinia())
 app.use(vuetify)
 
 const workspacesStore = useWorkspacesStore()
+const spacesStore = useSpacesStore()
 
 await Promise.all([
   workspacesStore.initializeWorkspaces(),
   useItemsStore().initializeItems(),
   useInterfaceStore().initializeInterface(),
+  useVisualizationsStore().initializeVisualizations(),
+  spacesStore.initializeSpaces(),
 ])
 
 workspacesStore.scrubAllWorkspaces()
+spacesStore.scrubAllSpaces()
 
 app.use(router)
 app.mount('#app')

--- a/src/views/SpaceView.vue
+++ b/src/views/SpaceView.vue
@@ -68,7 +68,9 @@ const workspaces = computed(() =>
       </v-card>
 
       <v-card variant="outlined">
-        <v-card-title class="text-body-1">Visualizations ({{ visualizations.length }})</v-card-title>
+        <v-card-title class="text-body-1"
+          >Visualizations ({{ visualizations.length }})</v-card-title
+        >
         <v-card-text>
           <pre>{{ JSON.stringify(visualizations, null, 2) }}</pre>
         </v-card-text>


### PR DESCRIPTION
## Summary

- Added `useSpacesStore` and `useVisualizationsStore` imports to `main.ts`
- Added `initializeSpaces()` and `initializeVisualizations()` calls to the startup `Promise.all` so both stores load persisted data from IndexedDB on reload
- Added `scrubAllSpaces()` call after initialization to remove any stale workspace/visualization IDs from spaces

Closes #125

## Test plan

- [ ] Create a space and a visualization, then reload the page — both should still appear
- [ ] Verify the app boots without errors in the browser console
- [ ] Verify existing workspaces/items/settings still load correctly after the change

https://claude.ai/code/session_01NeinnQUwuRybz3YsYWPTNy