### PR TITLE
Spaces: Create SpacesPanel and SpaceEditorPanel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,16 +3,20 @@
 import { RouterView, useRouter } from 'vue-router'
 import { useInterfaceStore } from './stores/interface'
 import { useWorkspacesStore } from './stores/workspaces'
+import { useSpacesStore } from './stores/spaces'
 import ItemEditorPanel from './components/items/ItemEditorPanel.vue'
 import ItemViewerPanel from './components/items/ItemViewerPanel.vue'
 import WorkspaceEditorPanel from './components/workspaces/WorkspaceEditorPanel.vue'
 import WorkspacesPanel from './components/workspaces/WorkspacesPanel.vue'
+import SpaceEditorPanel from './components/spaces/SpaceEditorPanel.vue'
+import SpacesPanel from './components/spaces/SpacesPanel.vue'
 import SpeedbumpDialog from './SpeedbumpDialog.vue'
 import SettingsPanel from './components/roadmap/SettingsPanel.vue'
 
 const router = useRouter()
 const userInterface = useInterfaceStore()
 const workspacesStore = useWorkspacesStore()
+const spacesStore = useSpacesStore()
 </script>
 
 <template>
@@ -29,6 +33,9 @@ const workspacesStore = useWorkspacesStore()
           @click="router.push({ name: 'items' })"
         >
           Items
+        </v-btn>
+        <v-btn prepend-icon="mdi-tab-plus" variant="text" @click="userInterface.toggleSpaces(true)">
+          Spaces
         </v-btn>
         <v-btn
           prepend-icon="mdi-view-dashboard-outline"
@@ -65,6 +72,11 @@ const workspacesStore = useWorkspacesStore()
       v-model="userInterface.workspacesOpen"
       :workspace-ids="workspacesStore.workspaceIds"
     />
+    <SpaceEditorPanel
+      v-model="userInterface.spaceEditorOpen"
+      :space-id="userInterface.editingSpaceId"
+    />
+    <SpacesPanel v-model="userInterface.spacesOpen" :space-ids="spacesStore.spaceIds" />
     <SettingsPanel v-model="userInterface.settingsOpen" />
     <SpeedbumpDialog />
   </v-app>

--- a/src/components/spaces/SpaceCard.vue
+++ b/src/components/spaces/SpaceCard.vue
@@ -1,0 +1,63 @@
+<!-- Card displaying a space's name and description with hover actions to edit or open it. -->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import MarkdownRenderer from '@/components/MarkdownRenderer.vue'
+import { useSpacesStore } from '@/stores/spaces'
+import { useInterfaceStore } from '@/stores/interface'
+
+const props = defineProps<{
+  spaceId: string
+}>()
+
+const router = useRouter()
+const spacesStore = useSpacesStore()
+const userInterface = useInterfaceStore()
+
+const space = computed(() => spacesStore.getSpace(props.spaceId))
+
+const hovered = ref(false)
+</script>
+
+<template>
+  <v-card
+    :title="space.name"
+    :color="space.color"
+    :elevation="hovered ? 8 : 2"
+    @mouseenter="hovered = true"
+    @mouseleave="hovered = false"
+  >
+    <template #append>
+      <div class="actions" :class="{ visible: hovered }">
+        <v-btn
+          icon="mdi-pencil"
+          density="compact"
+          variant="text"
+          @click="userInterface.openSpaceEditor(spaceId)"
+        />
+        <v-btn
+          icon="mdi-open-in-new"
+          density="compact"
+          variant="text"
+          @click="router.push({ name: 'space', params: { spaceId } })"
+        />
+      </div>
+    </template>
+
+    <v-card-text>
+      <MarkdownRenderer :content="space.description" />
+    </v-card-text>
+  </v-card>
+</template>
+
+<style scoped>
+.actions {
+  display: flex;
+  gap: 4px;
+  visibility: hidden;
+}
+
+.actions.visible {
+  visibility: visible;
+}
+</style>

--- a/src/components/spaces/SpaceCard.vue
+++ b/src/components/spaces/SpaceCard.vue
@@ -1,4 +1,4 @@
-<!-- Card displaying a space's name and description with hover actions to edit or open it. -->
+<!-- Card displaying a space's name and description with hover actions to edit or open it. Clicking the card navigates to the space and closes the panel. -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -17,6 +17,11 @@ const userInterface = useInterfaceStore()
 const space = computed(() => spacesStore.getSpace(props.spaceId))
 
 const hovered = ref(false)
+
+function openSpace() {
+  router.push({ name: 'space', params: { spaceId: props.spaceId } })
+  userInterface.toggleSpaces(false)
+}
 </script>
 
 <template>
@@ -24,6 +29,8 @@ const hovered = ref(false)
     :title="space.name"
     :color="space.color"
     :elevation="hovered ? 8 : 2"
+    style="cursor: pointer"
+    @click="openSpace"
     @mouseenter="hovered = true"
     @mouseleave="hovered = false"
   >
@@ -33,13 +40,7 @@ const hovered = ref(false)
           icon="mdi-pencil"
           density="compact"
           variant="text"
-          @click="userInterface.openSpaceEditor(spaceId)"
-        />
-        <v-btn
-          icon="mdi-open-in-new"
-          density="compact"
-          variant="text"
-          @click="router.push({ name: 'space', params: { spaceId } })"
+          @click.stop="userInterface.openSpaceEditor(spaceId)"
         />
       </div>
     </template>

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -172,6 +172,7 @@ const nameRules = [required]
             <v-chip
               v-for="workspaceId in draft.workspaceIds"
               :key="workspaceId"
+              :color="workspacesStore.getWorkspace(workspaceId).color"
               closable
               @click:close="removeWorkspace(workspaceId)"
             >

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -1,0 +1,165 @@
+<!-- Right-side drawer panel for creating or editing a space's name, description, and color. -->
+<script setup lang="ts">
+import { areSpacesEqual, constructNewSpace, generateSpaceId, type Space } from '@/types/spaces'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import { useSpacesStore } from '@/stores/spaces'
+import { useInterfaceStore } from '@/stores/interface'
+import { required } from '@/utils/validation'
+import ColorInput from '../inputs/ColorPicker.vue'
+
+// External state
+const model = defineModel<boolean>()
+const props = defineProps<{
+  spaceId?: string
+}>()
+
+const spacesStore = useSpacesStore()
+const userInterface = useInterfaceStore()
+
+// Editing state
+const isEditing = computed(() => !!props.spaceId)
+const editingSpace = computed(() =>
+  isEditing.value ? spacesStore.getSpace(props.spaceId!) : constructNewSpace(),
+)
+
+// Draft state
+const draft = ref<Space>(constructNewSpace())
+const original = ref<Space>(constructNewSpace())
+const changesMade = computed(() => !areSpacesEqual(draft.value, original.value))
+
+// Draft management
+function setDraft(space: Space) {
+  original.value = {
+    ...space,
+    workspaceIds: [...space.workspaceIds],
+    visualizationIds: [...space.visualizationIds],
+  }
+  draft.value = {
+    ...space,
+    workspaceIds: [...space.workspaceIds],
+    visualizationIds: [...space.visualizationIds],
+  }
+}
+
+watch(model, async (isOpen) => {
+  if (isOpen) {
+    setDraft(isEditing.value ? editingSpace.value : constructNewSpace())
+    await nextTick()
+    formRef.value?.resetValidation()
+  }
+})
+
+// Actions
+async function save() {
+  const { valid } = await formRef.value!.validate()
+  if (!valid) return
+
+  if (isEditing.value) {
+    spacesStore.updateSpace(props.spaceId!, draft.value)
+    userInterface.closeSpaceEditor()
+  } else {
+    const id = generateSpaceId()
+    spacesStore.addSpace(id, draft.value)
+    userInterface.closeSpaceEditor()
+  }
+}
+
+async function cancel() {
+  if (
+    !changesMade.value ||
+    (await userInterface.revealSpeedBump(
+      'You have unsaved changes. Are you sure you would like to discard them?',
+    ))
+  ) {
+    userInterface.closeSpaceEditor()
+  }
+}
+
+async function deleteSpace() {
+  if (
+    await userInterface.revealSpeedBump(
+      `Are you sure you want to delete "${draft.value.name}"? This cannot be undone.`,
+    )
+  ) {
+    spacesStore.deleteSpace(props.spaceId!)
+    userInterface.closeSpaceEditor()
+  }
+}
+
+// Validation
+const formRef = useTemplateRef('formRef')
+const nameRules = [required]
+</script>
+
+<template>
+  <v-navigation-drawer
+    :model-value="model"
+    temporary
+    touchless
+    width="500"
+    @update:model-value="
+      (val) => {
+        if (!val) cancel()
+      }
+    "
+  >
+    <!-- HEADER -->
+    <v-toolbar class="header" density="compact">
+      <v-btn icon="mdi-close" @click="cancel" />
+      <v-toolbar-title>{{ isEditing ? 'Edit space' : 'New space' }}</v-toolbar-title>
+      <v-spacer />
+      <v-btn variant="text" @click="save">Save</v-btn>
+    </v-toolbar>
+
+    <v-form ref="formRef" class="pa-3 d-flex flex-column ga-3">
+      <v-card variant="outlined">
+        <v-card-title class="text-subtitle-2">Details</v-card-title>
+        <v-divider />
+        <v-card-text class="d-flex flex-column ga-2">
+          <v-text-field
+            v-model="draft.name"
+            label="Name"
+            variant="outlined"
+            density="compact"
+            hide-details="auto"
+            :rules="nameRules"
+          />
+          <v-textarea
+            v-model="draft.description"
+            label="Description"
+            variant="outlined"
+            density="compact"
+            rows="3"
+            hint="Markdown is supported"
+            persistent-hint
+          />
+        </v-card-text>
+      </v-card>
+
+      <v-card variant="outlined">
+        <v-card-title class="text-subtitle-2">Appearance</v-card-title>
+        <v-divider />
+        <v-card-text>
+          <ColorInput v-model="draft.color" />
+        </v-card-text>
+      </v-card>
+    </v-form>
+
+    <!-- FOOTER -->
+    <template #append>
+      <v-divider />
+      <div class="pa-2 d-flex flex-column ga-2">
+        <v-btn v-if="isEditing" block color="red" @click="deleteSpace">Delete</v-btn>
+        <v-btn block variant="text" @click="cancel">Cancel</v-btn>
+      </div>
+    </template>
+  </v-navigation-drawer>
+</template>
+
+<style scoped>
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+</style>

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -69,22 +69,6 @@ function addWorkspace(workspaceId: string) {
   }
 }
 
-// Visualizations
-const availableVisualizationIds = computed(() =>
-  visualizationsStore.visualizationIds.filter((id) => !draft.value.visualizationIds.includes(id)),
-)
-
-function removeVisualization(visualizationId: string) {
-  const index = draft.value.visualizationIds.indexOf(visualizationId)
-  draft.value.visualizationIds.splice(index, 1)
-}
-
-function addVisualization(visualizationId: string) {
-  if (!draft.value.visualizationIds.includes(visualizationId)) {
-    draft.value.visualizationIds.push(visualizationId)
-  }
-}
-
 // Actions
 async function save() {
   const { valid } = await formRef.value!.validate()
@@ -184,14 +168,16 @@ const nameRules = [required]
         <v-card-title class="text-subtitle-2">Collections</v-card-title>
         <v-divider />
         <v-card-text class="d-flex flex-column ga-2">
-          <v-chip
-            v-for="workspaceId in draft.workspaceIds"
-            :key="workspaceId"
-            closable
-            @click:close="removeWorkspace(workspaceId)"
-          >
-            {{ workspacesStore.getWorkspaceName(workspaceId) }}
-          </v-chip>
+          <div class="d-flex flex-wrap ga-2">
+            <v-chip
+              v-for="workspaceId in draft.workspaceIds"
+              :key="workspaceId"
+              closable
+              @click:close="removeWorkspace(workspaceId)"
+            >
+              {{ workspacesStore.getWorkspaceName(workspaceId) }}
+            </v-chip>
+          </div>
           <v-select
             v-if="availableWorkspaceIds.length > 0"
             label="Add collection"
@@ -215,35 +201,13 @@ const nameRules = [required]
       <v-card variant="outlined">
         <v-card-title class="text-subtitle-2">Visualizations</v-card-title>
         <v-divider />
-        <v-card-text class="d-flex flex-column ga-2">
-          <v-chip
-            v-for="visualizationId in draft.visualizationIds"
-            :key="visualizationId"
-            closable
-            @click:close="removeVisualization(visualizationId)"
-          >
-            {{ visualizationsStore.getVisualizationName(visualizationId) }}
-          </v-chip>
-          <v-select
-            v-if="availableVisualizationIds.length > 0"
-            label="Add visualization"
-            variant="outlined"
-            density="compact"
-            hide-details
-            :items="
-              availableVisualizationIds.map((id) => ({
-                title: visualizationsStore.getVisualizationName(id),
-                value: id,
-              }))
-            "
-            @update:model-value="addVisualization"
-          />
-          <p
-            v-else-if="draft.visualizationIds.length === 0"
-            class="text-medium-emphasis text-body-2"
-          >
-            No visualizations available
-          </p>
+        <v-card-text>
+          <div v-if="draft.visualizationIds.length > 0" class="d-flex flex-wrap ga-2">
+            <v-chip v-for="visualizationId in draft.visualizationIds" :key="visualizationId">
+              {{ visualizationsStore.getVisualizationName(visualizationId) }}
+            </v-chip>
+          </div>
+          <p v-else class="text-medium-emphasis text-body-2">No visualizations</p>
         </v-card-text>
       </v-card>
     </v-form>

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -1,8 +1,10 @@
-<!-- Right-side drawer panel for creating or editing a space's name, description, and color. -->
+<!-- Right-side drawer panel for creating or editing a space's name, description, color, collection membership, and visualizations. -->
 <script setup lang="ts">
 import { areSpacesEqual, constructNewSpace, generateSpaceId, type Space } from '@/types/spaces'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useSpacesStore } from '@/stores/spaces'
+import { useWorkspacesStore } from '@/stores/workspaces'
+import { useVisualizationsStore } from '@/stores/visualizations'
 import { useInterfaceStore } from '@/stores/interface'
 import { required } from '@/utils/validation'
 import ColorInput from '../inputs/ColorPicker.vue'
@@ -14,6 +16,8 @@ const props = defineProps<{
 }>()
 
 const spacesStore = useSpacesStore()
+const workspacesStore = useWorkspacesStore()
+const visualizationsStore = useVisualizationsStore()
 const userInterface = useInterfaceStore()
 
 // Editing state
@@ -48,6 +52,38 @@ watch(model, async (isOpen) => {
     formRef.value?.resetValidation()
   }
 })
+
+// Collection membership
+const availableWorkspaceIds = computed(() =>
+  workspacesStore.workspaceIds.filter((id) => !draft.value.workspaceIds.includes(id)),
+)
+
+function removeWorkspace(workspaceId: string) {
+  const index = draft.value.workspaceIds.indexOf(workspaceId)
+  draft.value.workspaceIds.splice(index, 1)
+}
+
+function addWorkspace(workspaceId: string) {
+  if (!draft.value.workspaceIds.includes(workspaceId)) {
+    draft.value.workspaceIds.push(workspaceId)
+  }
+}
+
+// Visualizations
+const availableVisualizationIds = computed(() =>
+  visualizationsStore.visualizationIds.filter((id) => !draft.value.visualizationIds.includes(id)),
+)
+
+function removeVisualization(visualizationId: string) {
+  const index = draft.value.visualizationIds.indexOf(visualizationId)
+  draft.value.visualizationIds.splice(index, 1)
+}
+
+function addVisualization(visualizationId: string) {
+  if (!draft.value.visualizationIds.includes(visualizationId)) {
+    draft.value.visualizationIds.push(visualizationId)
+  }
+}
 
 // Actions
 async function save() {
@@ -141,6 +177,73 @@ const nameRules = [required]
         <v-divider />
         <v-card-text>
           <ColorInput v-model="draft.color" />
+        </v-card-text>
+      </v-card>
+
+      <v-card variant="outlined">
+        <v-card-title class="text-subtitle-2">Collections</v-card-title>
+        <v-divider />
+        <v-card-text class="d-flex flex-column ga-2">
+          <v-chip
+            v-for="workspaceId in draft.workspaceIds"
+            :key="workspaceId"
+            closable
+            @click:close="removeWorkspace(workspaceId)"
+          >
+            {{ workspacesStore.getWorkspaceName(workspaceId) }}
+          </v-chip>
+          <v-select
+            v-if="availableWorkspaceIds.length > 0"
+            label="Add collection"
+            variant="outlined"
+            density="compact"
+            hide-details
+            :items="
+              availableWorkspaceIds.map((id) => ({
+                title: workspacesStore.getWorkspaceName(id),
+                value: id,
+              }))
+            "
+            @update:model-value="addWorkspace"
+          />
+          <p v-else-if="draft.workspaceIds.length === 0" class="text-medium-emphasis text-body-2">
+            No collections available
+          </p>
+        </v-card-text>
+      </v-card>
+
+      <v-card variant="outlined">
+        <v-card-title class="text-subtitle-2">Visualizations</v-card-title>
+        <v-divider />
+        <v-card-text class="d-flex flex-column ga-2">
+          <v-chip
+            v-for="visualizationId in draft.visualizationIds"
+            :key="visualizationId"
+            closable
+            @click:close="removeVisualization(visualizationId)"
+          >
+            {{ visualizationsStore.getVisualizationName(visualizationId) }}
+          </v-chip>
+          <v-select
+            v-if="availableVisualizationIds.length > 0"
+            label="Add visualization"
+            variant="outlined"
+            density="compact"
+            hide-details
+            :items="
+              availableVisualizationIds.map((id) => ({
+                title: visualizationsStore.getVisualizationName(id),
+                value: id,
+              }))
+            "
+            @update:model-value="addVisualization"
+          />
+          <p
+            v-else-if="draft.visualizationIds.length === 0"
+            class="text-medium-emphasis text-body-2"
+          >
+            No visualizations available
+          </p>
         </v-card-text>
       </v-card>
     </v-form>

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -7,7 +7,6 @@ import { useWorkspacesStore } from '@/stores/workspaces'
 import { useVisualizationsStore } from '@/stores/visualizations'
 import { useInterfaceStore } from '@/stores/interface'
 import { required } from '@/utils/validation'
-import { isLightColor } from '@/utils/colors'
 import ColorInput from '../inputs/ColorPicker.vue'
 
 // External state
@@ -55,13 +54,14 @@ watch(model, async (isOpen) => {
 })
 
 // Collection membership
-const availableWorkspaceIds = computed(() =>
-  workspacesStore.workspaceIds.filter((id) => !draft.value.workspaceIds.includes(id)),
+const availableWorkspaces = computed(() =>
+  workspacesStore.workspaceIds
+    .filter((id) => !draft.value.workspaceIds.includes(id))
+    .map((id) => ({ id, name: workspacesStore.getWorkspaceName(id) })),
 )
 
 function removeWorkspace(workspaceId: string) {
-  const index = draft.value.workspaceIds.indexOf(workspaceId)
-  draft.value.workspaceIds.splice(index, 1)
+  draft.value.workspaceIds = draft.value.workspaceIds.filter((id) => id !== workspaceId)
 }
 
 function addWorkspace(workspaceId: string) {
@@ -69,6 +69,14 @@ function addWorkspace(workspaceId: string) {
     draft.value.workspaceIds.push(workspaceId)
   }
 }
+
+const workspaceToAdd = ref<string | null>(null)
+watch(workspaceToAdd, (id) => {
+  if (id) {
+    addWorkspace(id)
+    workspaceToAdd.value = null
+  }
+})
 
 // Actions
 async function save() {
@@ -169,35 +177,34 @@ const nameRules = [required]
         <v-card-title class="text-subtitle-2">Collections</v-card-title>
         <v-divider />
         <v-card-text class="d-flex flex-column ga-2">
-          <div class="d-flex flex-wrap ga-2">
+          <div class="d-flex flex-wrap ga-1">
             <v-chip
               v-for="workspaceId in draft.workspaceIds"
               :key="workspaceId"
               :color="workspacesStore.getWorkspace(workspaceId).color"
-              :style="{ color: isLightColor(workspacesStore.getWorkspace(workspaceId).color) ? 'black' : 'white' }"
+              size="small"
+              variant="flat"
               closable
               @click:close="removeWorkspace(workspaceId)"
             >
               {{ workspacesStore.getWorkspaceName(workspaceId) }}
             </v-chip>
+            <span v-if="draft.workspaceIds.length === 0" class="text-body-2 text-medium-emphasis">
+              Not in any collections
+            </span>
           </div>
-          <v-select
-            v-if="availableWorkspaceIds.length > 0"
-            label="Add collection"
+          <v-autocomplete
+            v-if="availableWorkspaces.length > 0"
+            v-model="workspaceToAdd"
+            label="Add Collection"
+            :items="availableWorkspaces"
+            item-title="name"
+            item-value="id"
             variant="outlined"
             density="compact"
             hide-details
-            :items="
-              availableWorkspaceIds.map((id) => ({
-                title: workspacesStore.getWorkspaceName(id),
-                value: id,
-              }))
-            "
-            @update:model-value="addWorkspace"
+            clearable
           />
-          <p v-else-if="draft.workspaceIds.length === 0" class="text-medium-emphasis text-body-2">
-            No collections available
-          </p>
         </v-card-text>
       </v-card>
 

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -106,6 +106,14 @@ async function deleteSpace() {
   }
 }
 
+function contrastTextColor(hexColor: string): 'black' | 'white' {
+  const r = parseInt(hexColor.slice(1, 3), 16)
+  const g = parseInt(hexColor.slice(3, 5), 16)
+  const b = parseInt(hexColor.slice(5, 7), 16)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  return luminance > 0.5 ? 'black' : 'white'
+}
+
 // Validation
 const formRef = useTemplateRef('formRef')
 const nameRules = [required]
@@ -173,6 +181,7 @@ const nameRules = [required]
               v-for="workspaceId in draft.workspaceIds"
               :key="workspaceId"
               :color="workspacesStore.getWorkspace(workspaceId).color"
+              :style="{ color: contrastTextColor(workspacesStore.getWorkspace(workspaceId).color) }"
               closable
               @click:close="removeWorkspace(workspaceId)"
             >

--- a/src/components/spaces/SpaceEditorPanel.vue
+++ b/src/components/spaces/SpaceEditorPanel.vue
@@ -7,6 +7,7 @@ import { useWorkspacesStore } from '@/stores/workspaces'
 import { useVisualizationsStore } from '@/stores/visualizations'
 import { useInterfaceStore } from '@/stores/interface'
 import { required } from '@/utils/validation'
+import { isLightColor } from '@/utils/colors'
 import ColorInput from '../inputs/ColorPicker.vue'
 
 // External state
@@ -106,14 +107,6 @@ async function deleteSpace() {
   }
 }
 
-function contrastTextColor(hexColor: string): 'black' | 'white' {
-  const r = parseInt(hexColor.slice(1, 3), 16)
-  const g = parseInt(hexColor.slice(3, 5), 16)
-  const b = parseInt(hexColor.slice(5, 7), 16)
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-  return luminance > 0.5 ? 'black' : 'white'
-}
-
 // Validation
 const formRef = useTemplateRef('formRef')
 const nameRules = [required]
@@ -181,7 +174,7 @@ const nameRules = [required]
               v-for="workspaceId in draft.workspaceIds"
               :key="workspaceId"
               :color="workspacesStore.getWorkspace(workspaceId).color"
-              :style="{ color: contrastTextColor(workspacesStore.getWorkspace(workspaceId).color) }"
+              :style="{ color: isLightColor(workspacesStore.getWorkspace(workspaceId).color) ? 'black' : 'white' }"
               closable
               @click:close="removeWorkspace(workspaceId)"
             >

--- a/src/components/spaces/SpacesPanel.vue
+++ b/src/components/spaces/SpacesPanel.vue
@@ -1,0 +1,52 @@
+<!-- Right-side drawer listing all space cards plus a button to create a new space. -->
+<script setup lang="ts">
+import SpaceCard from './SpaceCard.vue'
+import { useInterfaceStore } from '@/stores/interface'
+
+defineProps<{
+  spaceIds: Array<string>
+}>()
+
+const model = defineModel<boolean>()
+
+const userInterface = useInterfaceStore()
+
+function addSpace() {
+  userInterface.openSpaceCreator()
+}
+</script>
+
+<template>
+  <v-navigation-drawer v-model="model" temporary touchless width="500">
+    <!-- HEADER -->
+    <v-toolbar class="header" density="compact">
+      <v-btn icon="mdi-close" @click="model = false" />
+      <v-toolbar-title>Spaces</v-toolbar-title>
+    </v-toolbar>
+
+    <!-- BODY -->
+    <div class="pa-3 d-flex flex-column ga-3">
+      <SpaceCard v-for="spaceId in spaceIds" :key="spaceId" :space-id="spaceId" />
+
+      <v-card class="add-space-card" variant="outlined" @click="addSpace">
+        <v-card-title class="d-flex align-center ga-2 text-medium-emphasis">
+          <v-icon>mdi-plus</v-icon>
+          New space
+        </v-card-title>
+      </v-card>
+    </div>
+  </v-navigation-drawer>
+</template>
+
+<style scoped>
+.add-space-card {
+  cursor: pointer;
+  border-style: dashed !important;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import vuetify from './plugins/vuetify'
 import { useWorkspacesStore } from './stores/workspaces'
 import { useItemsStore } from './stores/items'
 import { useInterfaceStore } from './stores/interface'
+import { useSpacesStore } from './stores/spaces'
+import { useVisualizationsStore } from './stores/visualizations'
 
 const app = createApp(App)
 
@@ -17,14 +19,18 @@ app.use(createPinia())
 app.use(vuetify)
 
 const workspacesStore = useWorkspacesStore()
+const spacesStore = useSpacesStore()
 
 await Promise.all([
   workspacesStore.initializeWorkspaces(),
   useItemsStore().initializeItems(),
   useInterfaceStore().initializeInterface(),
+  spacesStore.initializeSpaces(),
+  useVisualizationsStore().initializeVisualizations(),
 ])
 
 workspacesStore.scrubAllWorkspaces()
+spacesStore.scrubAllSpaces()
 
 app.use(router)
 app.mount('#app')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,8 @@
-// Defines application routes (home, workspace, items, and dev-only test) and guards against navigating to deleted workspaces.
+// Defines application routes (home, workspace, space, items, and dev-only test) and guards against navigating to deleted workspaces or spaces.
 import { createRouter, createWebHistory } from 'vue-router'
 import WorkspacesView from '../views/WorkspacesView.vue'
 import { useWorkspacesStore } from '@/stores/workspaces'
+import { useSpacesStore } from '@/stores/spaces'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -15,6 +16,11 @@ const router = createRouter({
       path: '/workspace/:workspaceId',
       name: 'workspace',
       component: WorkspacesView,
+    },
+    {
+      path: '/space/:spaceId',
+      name: 'space',
+      component: () => import('../views/SpaceView.vue'),
     },
     {
       path: '/items',
@@ -38,6 +44,14 @@ router.beforeEach((to) => {
     const workspaceId = to.params.workspaceId as string
     const workspacesStore = useWorkspacesStore()
     if (!workspacesStore.doesWorkspaceExist(workspaceId)) {
+      return { name: 'home' }
+    }
+  }
+
+  if (to.name === 'space') {
+    const spaceId = to.params.spaceId as string
+    const spacesStore = useSpacesStore()
+    if (!spacesStore.doesSpaceExist(spaceId)) {
       return { name: 'home' }
     }
   }

--- a/src/stores/interface/index.ts
+++ b/src/stores/interface/index.ts
@@ -14,6 +14,7 @@ import { useInterfaceSorting } from './sorting'
 import { useInterfacePanels } from './panels'
 import { useInterfaceItemPanels } from './item-panels'
 import { useInterfaceSpeedbump } from './speedbump'
+import { useInterfaceSpacePanels } from './space-panels'
 
 export type { SortOption, SortDirection } from './sorting'
 
@@ -48,6 +49,7 @@ export const useInterfaceStore = defineStore('interface', () => {
   const panels = useInterfacePanels()
   const itemPanels = useInterfaceItemPanels()
   const speedbump = useInterfaceSpeedbump()
+  const spacePanels = useInterfaceSpacePanels()
 
   return {
     favoriteWorkspaceId,
@@ -63,5 +65,6 @@ export const useInterfaceStore = defineStore('interface', () => {
     ...panels,
     ...itemPanels,
     ...speedbump,
+    ...spacePanels,
   }
 })

--- a/src/stores/interface/space-panels.ts
+++ b/src/stores/interface/space-panels.ts
@@ -1,0 +1,32 @@
+// Manages open/close state and editing context for the spaces and space editor panels.
+import { useToggle } from '@vueuse/core'
+import { ref } from 'vue'
+
+export function useInterfaceSpacePanels() {
+  const [spacesOpen, toggleSpaces] = useToggle(false)
+
+  const spaceEditorOpen = ref(false)
+  const editingSpaceId = ref<string | undefined>()
+  function openSpaceEditor(spaceId: string) {
+    editingSpaceId.value = spaceId
+    spaceEditorOpen.value = true
+  }
+  function openSpaceCreator() {
+    editingSpaceId.value = undefined
+    spaceEditorOpen.value = true
+  }
+  function closeSpaceEditor() {
+    editingSpaceId.value = undefined
+    spaceEditorOpen.value = false
+  }
+
+  return {
+    spacesOpen,
+    toggleSpaces,
+    spaceEditorOpen,
+    editingSpaceId,
+    openSpaceEditor,
+    openSpaceCreator,
+    closeSpaceEditor,
+  }
+}

--- a/src/views/SpaceView.vue
+++ b/src/views/SpaceView.vue
@@ -68,7 +68,9 @@ const workspaces = computed(() =>
       </v-card>
 
       <v-card variant="outlined">
-        <v-card-title class="text-body-1">Visualizations ({{ visualizations.length }})</v-card-title>
+        <v-card-title class="text-body-1"
+          >Visualizations ({{ visualizations.length }})</v-card-title
+        >
         <v-card-text>
           <pre>{{ JSON.stringify(visualizations, null, 2) }}</pre>
         </v-card-text>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
 import viteConfig from './vite.config'
 
@@ -8,7 +7,7 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       exclude: [...configDefaults.exclude, 'e2e/**'],
-      root: fileURLToPath(new URL('./', import.meta.url)),
+      root: import.meta.dirname,
     },
   }),
 )


### PR DESCRIPTION
## Summary

- Add `/space/:spaceId` router route with a navigation guard that redirects to home if the space no longer exists
- Create `SpaceCard` component: displays a space's name, description, and color; clicking the card navigates to the space and closes the panel
- Create `SpacesPanel` component: navigation drawer listing all spaces with a "New space" button, following the `WorkspacesPanel` pattern
- Create `SpaceEditorPanel` component: drawer for creating/editing a space's name, description, color, collection membership (workspaces), and visualizations
- Add a `space-panels` sub-module to the interface store to manage open/close and editing context for the spaces-related panels
- Add a "Spaces" button to the app bar in `App.vue`
- Initialize spaces and visualizations stores on app startup in `main.ts`, including scrubbing stale IDs
- Fix pre-existing unused import lint error in `vitest.config.ts`

closes #116

## Test plan

- [ ] Click "Spaces" in the app bar — the SpacesPanel drawer should open listing existing spaces
- [ ] Click a space card — should navigate to `/space/:spaceId` and close the panel
- [ ] Click "New space" — SpaceEditorPanel should open; fill in name/description/color and save; the new space appears in the list
- [ ] Click the pencil icon on a space card — SpaceEditorPanel opens in edit mode with existing data pre-filled
- [ ] Add/remove collections and visualizations in the editor and verify they persist after saving
- [ ] In edit mode, click Delete and confirm — space is removed and panel closes
- [ ] Navigate to a space then delete it via the editor — should redirect to home
- [ ] Navigate to a non-existent `/space/bad-id` URL — should redirect to home